### PR TITLE
Update IERC20.sol syntax to conform to Laoland

### DIFF
--- a/contracts/utils/IERC20.sol
+++ b/contracts/utils/IERC20.sol
@@ -17,12 +17,13 @@ interface IERC20 {
 
     function balanceOf(address who) external view returns (uint256);
 
-    function allowance(address owner, address spender)
-        external
-        view
-        returns (uint256);
+    function allowance(address owner, address spender) external view returns (uint256);
 
-    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Transfer(
+        address indexed from, 
+        address indexed to, 
+        uint256 value
+    );
 
     event Approval(
         address indexed owner,


### PR DESCRIPTION
conform to laoland syntax, which seems to provide vertical list of params when 3 or more.