### PR TITLE
GH-56: Guild Kick Adapter

### DIFF
--- a/contracts/adapters/GuildKick.sol
+++ b/contracts/adapters/GuildKick.sol
@@ -82,10 +82,10 @@ contract GuildKickContract is IGuildKick, DaoConstants, MemberGuard {
         // If status is empty or DONE we expect it to fail
         require(
             guildKick.status == GuildKickStatus.IN_PROGRESS,
-            "guild kick already completed"
+            "guild kick already completed or does not exist"
         );
 
-        // Only active members should be able to call the kick
+        // Only active members can be kicked out, which means the member is in jail already
         require(
             dao.isActiveMember(memberToKick),
             "memberToKick is not active"
@@ -94,7 +94,7 @@ contract GuildKickContract is IGuildKick, DaoConstants, MemberGuard {
         // If the proposal id does not match the storage one, we expect it to fail
         require(
             guildKick.proposalId == proposalId,
-            "wrong kick proposal"
+            "invalid kick proposal"
         );
 
         IVoting votingContract = IVoting(dao.getAdapterAddress(VOTING));

--- a/contracts/adapters/GuildKick.sol
+++ b/contracts/adapters/GuildKick.sol
@@ -1,0 +1,116 @@
+pragma solidity ^0.7.0;
+
+// SPDX-License-Identifier: MIT
+
+import "../core/DaoConstants.sol";
+import "../core/DaoRegistry.sol";
+import "../guards/MemberGuard.sol";
+import "./interfaces/IGuildKick.sol";
+import "../utils/SafeMath.sol";
+import "../adapters/interfaces/IVoting.sol";
+
+/**
+MIT License
+
+Copyright (c) 2020 Openlaw
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+contract GuildKickContract is IGuildKick, DaoConstants, MemberGuard {
+    using SafeMath for uint256;
+    enum GuildKickStatus {IN_PROGRESS, DONE}
+
+    struct GuildKick {
+        uint64 proposalId;
+        GuildKickStatus status;
+        bytes data;
+    }
+
+    mapping(address => GuildKick) public kicks;
+
+    /*
+     * default fallback function to prevent from sending ether to the contract
+     */
+    receive() external payable {
+        revert("fallback revert");
+    }
+
+    function submitKickProposal(
+        DaoRegistry dao,
+        address memberToKick,
+        bytes calldata data
+    ) external override onlyMember(dao) returns (uint256) {
+        require(
+            kicks[memberToKick].proposalId > 0,
+            "guild kick already in progress"
+        );
+
+        // A kick proposal is created and needs to be voted
+        uint64 proposalId = dao.submitProposal(msg.sender);
+
+        GuildKick storage guildKick = kicks[memberToKick];
+        guildKick.proposalId = proposalId;
+        guildKick.status = GuildKickStatus.IN_PROGRESS;
+        guildKick.data = data;
+
+        // start the voting process for the guild kick proposal
+        IVoting votingContract = IVoting(dao.getAdapterAddress(VOTING));
+        votingContract.startNewVotingForProposal(dao, proposalId, data);
+        dao.sponsorProposal(proposalId, msg.sender);
+
+        return proposalId;
+    }
+
+    function guildKick(
+        DaoRegistry dao,
+        address memberToKick,
+        uint64 proposalId
+    ) external override onlyMember(dao) {
+        require(
+            dao.isActiveMember(memberToKick),
+            "memberToKick is not active"
+        );
+
+        GuildKick storage kick = kicks[memberToKick];
+        require(
+            kick.status == GuildKickStatus.IN_PROGRESS,
+            "guildkick not in progress"
+        );
+
+        IVoting votingContract = IVoting(dao.getAdapterAddress(VOTING));
+        require(
+            votingContract.voteResult(dao, proposalId) == 2,
+            "proposal did not pass yet"
+        );
+
+        // Member needs to have enough voting shares to be kicked
+        uint256 sharesToLock = dao.balanceOf(memberToKick, SHARES);
+        require(sharesToLock > 0, "insufficient shares");
+
+        // send to jail and convert all voting shares into loot to remove the voting power
+        dao.subtractFromBalance(memberToKick, SHARES, sharesToLock);
+        dao.addToBalance(memberToKick, LOOT, sharesToLock);
+        dao.jailMember(memberToKick);
+        kick.status = GuildKickStatus.DONE;
+
+        dao.processProposal(proposalId);
+    }
+    
+}

--- a/contracts/adapters/GuildKick.sol
+++ b/contracts/adapters/GuildKick.sol
@@ -86,16 +86,10 @@ contract GuildKickContract is IGuildKick, DaoConstants, MemberGuard {
         );
 
         // Only active members can be kicked out, which means the member is in jail already
-        require(
-            dao.isActiveMember(memberToKick),
-            "memberToKick is not active"
-        );
+        require(dao.isActiveMember(memberToKick), "memberToKick is not active");
 
         // If the proposal id does not match the storage one, we expect it to fail
-        require(
-            guildKick.proposalId == proposalId,
-            "invalid kick proposal"
-        );
+        require(guildKick.proposalId == proposalId, "invalid kick proposal");
 
         IVoting votingContract = IVoting(dao.getAdapterAddress(VOTING));
         require(
@@ -115,5 +109,4 @@ contract GuildKickContract is IGuildKick, DaoConstants, MemberGuard {
 
         dao.processProposal(proposalId);
     }
-    
 }

--- a/contracts/adapters/interfaces/IGuildKick.sol
+++ b/contracts/adapters/interfaces/IGuildKick.sol
@@ -35,7 +35,7 @@ interface IGuildKick {
         bytes calldata data
     ) external returns (uint256);
 
-    function guildKick(
+    function kick(
         DaoRegistry dao,
         address memberToKick,
         uint64 proposalId

--- a/contracts/adapters/interfaces/IGuildKick.sol
+++ b/contracts/adapters/interfaces/IGuildKick.sol
@@ -35,9 +35,5 @@ interface IGuildKick {
         bytes calldata data
     ) external returns (uint256);
 
-    function kick(
-        DaoRegistry dao,
-        address memberToKick,
-        uint64 proposalId
-    ) external;
+    function kick(DaoRegistry dao, uint64 proposalId) external;
 }

--- a/contracts/adapters/interfaces/IGuildKick.sol
+++ b/contracts/adapters/interfaces/IGuildKick.sol
@@ -2,6 +2,8 @@ pragma solidity ^0.7.0;
 
 // SPDX-License-Identifier: MIT
 
+import "../../core/DaoRegistry.sol";
+
 /**
 MIT License
 
@@ -26,24 +28,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
 
-abstract contract DaoConstants {
-    // Adapters
-    bytes32 public constant VOTING = keccak256("voting");
-    bytes32 public constant ONBOARDING = keccak256("onboarding");
-    bytes32 public constant NONVOTING_ONBOARDING = keccak256(
-        "nonvoting-onboarding"
-    );
-    bytes32 public constant FINANCING = keccak256("financing");
-    bytes32 public constant MANAGING = keccak256("managing");
-    bytes32 public constant RAGEQUIT = keccak256("ragequit");
-    bytes32 public constant GUILDKICK = keccak256("guildkick");
+interface IGuildKick {
+    function submitKickProposal(
+        DaoRegistry dao,
+        address memberToKick,
+        bytes calldata data
+    ) external returns (uint256);
 
-    /// @notice The reserved address for Guild bank account
-    address public constant GUILD = address(0xdead);
-    /// @notice The reserved address for Total funds bank account
-    address public constant TOTAL = address(0xbabe);
-    address public constant SHARES = address(0xFF1CE);
-    address public constant LOOT = address(0xB105F00D);
-    address public constant LOCKED_LOOT = address(0xBAAAAAAD);
-    address public constant ETH_TOKEN = address(0x0);
+    function guildKick(
+        DaoRegistry dao,
+        address memberToKick,
+        uint64 proposalId
+    ) external;
 }

--- a/test/adapters/guildkick.test.js
+++ b/test/adapters/guildkick.test.js
@@ -169,4 +169,22 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     });
     assert.equal(activeMember.toString(), "false");
   });
+
+  it("should not be possible for a non-member to submit a guild kick proposal", async () => {});
+
+  it("should not be possible for a non-active member to submit a guild kick proposal", async () => {});
+
+  it("should not be possible for a non-member to process a kick proposal", async () => {});
+
+  it("should not be possible for a non-active member to process a kick proposal", async () => {});
+
+  it("should not be possible to process a kick proposal that is not in progress", async () => {});
+
+  it("should not be possible to process a kick proposal for a kicked member that is not active", async () => {});
+
+  it("should not be possible to process a kick proposal using the wrong proposal id", async () => {});
+
+  it("should not be possible to process a kick proposal if the voting did not pass", async () => {});
+
+  it("should not be possible to process a kick proposal if the member to kick does not have any shares", async () => {});
 });

--- a/test/adapters/guildkick.test.js
+++ b/test/adapters/guildkick.test.js
@@ -21,12 +21,17 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
+
+// Whole-script strict mode syntax
+"use strict";
+
 const {
   sha3,
   toBN,
   fromUtf8,
   advanceTime,
   createDao,
+  getContract,
   sharePrice,
   GUILD,
   ETH_TOKEN,
@@ -34,7 +39,9 @@ const {
   OnboardingContract,
   VotingContract,
   GuildKickContract,
+  FinancingContract,
   LOOT,
+  ManagingContract,
 } = require("../../utils/DaoFactory.js");
 
 contract("LAOLAND - GuildKick Adapter", async (accounts) => {
@@ -130,12 +137,13 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     const newMember = accounts[2];
 
     let dao = await createDao(member);
-    const onboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
-    const onboarding = await OnboardingContract.at(onboardingAddress);
-    const votingAddress = await dao.getAdapterAddress(sha3("voting"));
-    const voting = await VotingContract.at(votingAddress);
-    const guildkickAddress = await dao.getAdapterAddress(sha3("guildkick"));
-    const guildkickContract = await GuildKickContract.at(guildkickAddress);
+    const onboarding = await getContract(dao, "onboarding", OnboardingContract);
+    const voting = await getContract(dao, "voting", VotingContract);
+    const guildkickContract = await getContract(
+      dao,
+      "guildkick",
+      GuildKickContract
+    );
     await onboardingNewMember(
       dao,
       onboarding,
@@ -204,8 +212,11 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     const nonMember = accounts[2];
 
     let dao = await createDao(member);
-    const guildkickAddress = await dao.getAdapterAddress(sha3("guildkick"));
-    const guildkickContract = await GuildKickContract.at(guildkickAddress);
+    const guildkickContract = await getContract(
+      dao,
+      "guildkick",
+      GuildKickContract
+    );
 
     // Non member attemps to submit a guild kick proposal
     try {
@@ -224,12 +235,13 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     const newMember = accounts[2];
 
     let dao = await createDao(member);
-    const onboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
-    const onboarding = await OnboardingContract.at(onboardingAddress);
-    const votingAddress = await dao.getAdapterAddress(sha3("voting"));
-    const voting = await VotingContract.at(votingAddress);
-    const guildkickAddress = await dao.getAdapterAddress(sha3("guildkick"));
-    const guildkickContract = await GuildKickContract.at(guildkickAddress);
+    const onboarding = await getContract(dao, "onboarding", OnboardingContract);
+    const voting = await getContract(dao, "voting", VotingContract);
+    const guildkickContract = await getContract(
+      dao,
+      "guildkick",
+      GuildKickContract
+    );
     await onboardingNewMember(
       dao,
       onboarding,
@@ -283,12 +295,13 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     const newMemberA = accounts[2];
 
     let dao = await createDao(member);
-    const onboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
-    const onboarding = await OnboardingContract.at(onboardingAddress);
-    const votingAddress = await dao.getAdapterAddress(sha3("voting"));
-    const voting = await VotingContract.at(votingAddress);
-    const guildkickAddress = await dao.getAdapterAddress(sha3("guildkick"));
-    const guildkickContract = await GuildKickContract.at(guildkickAddress);
+    const onboarding = await getContract(dao, "onboarding", OnboardingContract);
+    const voting = await getContract(dao, "voting", VotingContract);
+    const guildkickContract = await getContract(
+      dao,
+      "guildkick",
+      GuildKickContract
+    );
 
     await onboardingNewMember(
       dao,
@@ -337,12 +350,13 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     const newMember = accounts[2];
 
     let dao = await createDao(member);
-    const onboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
-    const onboarding = await OnboardingContract.at(onboardingAddress);
-    const votingAddress = await dao.getAdapterAddress(sha3("voting"));
-    const voting = await VotingContract.at(votingAddress);
-    const guildkickAddress = await dao.getAdapterAddress(sha3("guildkick"));
-    const guildkickContract = await GuildKickContract.at(guildkickAddress);
+    const onboarding = await getContract(dao, "onboarding", OnboardingContract);
+    const voting = await getContract(dao, "voting", VotingContract);
+    const guildkickContract = await getContract(
+      dao,
+      "guildkick",
+      GuildKickContract
+    );
 
     await onboardingNewMember(
       dao,
@@ -396,12 +410,13 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     const newMember = accounts[2];
 
     let dao = await createDao(member);
-    const onboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
-    const onboarding = await OnboardingContract.at(onboardingAddress);
-    const votingAddress = await dao.getAdapterAddress(sha3("voting"));
-    const voting = await VotingContract.at(votingAddress);
-    const guildkickAddress = await dao.getAdapterAddress(sha3("guildkick"));
-    const guildkickContract = await GuildKickContract.at(guildkickAddress);
+    const onboarding = await getContract(dao, "onboarding", OnboardingContract);
+    const voting = await getContract(dao, "voting", VotingContract);
+    const guildkickContract = await getContract(
+      dao,
+      "guildkick",
+      GuildKickContract
+    );
 
     await onboardingNewMember(
       dao,
@@ -454,12 +469,13 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     const newMember = accounts[2];
 
     let dao = await createDao(member);
-    const onboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
-    const onboarding = await OnboardingContract.at(onboardingAddress);
-    const votingAddress = await dao.getAdapterAddress(sha3("voting"));
-    const voting = await VotingContract.at(votingAddress);
-    const guildkickAddress = await dao.getAdapterAddress(sha3("guildkick"));
-    const guildkickContract = await GuildKickContract.at(guildkickAddress);
+    const onboarding = await getContract(dao, "onboarding", OnboardingContract);
+    const voting = await getContract(dao, "voting", VotingContract);
+    const guildkickContract = await getContract(
+      dao,
+      "guildkick",
+      GuildKickContract
+    );
 
     await onboardingNewMember(
       dao,
@@ -512,12 +528,13 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     const newMember = accounts[2];
 
     let dao = await createDao(member);
-    const onboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
-    const onboarding = await OnboardingContract.at(onboardingAddress);
-    const votingAddress = await dao.getAdapterAddress(sha3("voting"));
-    const voting = await VotingContract.at(votingAddress);
-    const guildkickAddress = await dao.getAdapterAddress(sha3("guildkick"));
-    const guildkickContract = await GuildKickContract.at(guildkickAddress);
+    const onboarding = await getContract(dao, "onboarding", OnboardingContract);
+    const voting = await getContract(dao, "voting", VotingContract);
+    const guildkickContract = await getContract(
+      dao,
+      "guildkick",
+      GuildKickContract
+    );
 
     await onboardingNewMember(
       dao,
@@ -573,12 +590,13 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     const newMember = accounts[2];
 
     let dao = await createDao(member);
-    const onboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
-    const onboarding = await OnboardingContract.at(onboardingAddress);
-    const votingAddress = await dao.getAdapterAddress(sha3("voting"));
-    const voting = await VotingContract.at(votingAddress);
-    const guildkickAddress = await dao.getAdapterAddress(sha3("guildkick"));
-    const guildkickContract = await GuildKickContract.at(guildkickAddress);
+    const onboarding = await getContract(dao, "onboarding", OnboardingContract);
+    const voting = await getContract(dao, "voting", VotingContract);
+    const guildkickContract = await getContract(
+      dao,
+      "guildkick",
+      GuildKickContract
+    );
 
     await onboardingNewMember(
       dao,
@@ -625,12 +643,13 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     const advisor = accounts[3];
 
     let dao = await createDao(member);
-    const onboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
-    const onboarding = await OnboardingContract.at(onboardingAddress);
-    const votingAddress = await dao.getAdapterAddress(sha3("voting"));
-    const voting = await VotingContract.at(votingAddress);
-    const guildkickAddress = await dao.getAdapterAddress(sha3("guildkick"));
-    const guildkickContract = await GuildKickContract.at(guildkickAddress);
+    const onboarding = await getContract(dao, "onboarding", OnboardingContract);
+    const voting = await getContract(dao, "voting", VotingContract);
+    const guildkickContract = await getContract(
+      dao,
+      "guildkick",
+      GuildKickContract
+    );
 
     // New member joins as an Advisor (only receives LOOT)
     await onboardingNewMember(
@@ -678,12 +697,13 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     const newMember = accounts[2];
 
     let dao = await createDao(member);
-    const onboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
-    const onboarding = await OnboardingContract.at(onboardingAddress);
-    const votingAddress = await dao.getAdapterAddress(sha3("voting"));
-    const voting = await VotingContract.at(votingAddress);
-    const guildkickAddress = await dao.getAdapterAddress(sha3("guildkick"));
-    const guildkickContract = await GuildKickContract.at(guildkickAddress);
+    const onboarding = await getContract(dao, "onboarding", OnboardingContract);
+    const voting = await getContract(dao, "voting", VotingContract);
+    const guildkickContract = await getContract(
+      dao,
+      "guildkick",
+      GuildKickContract
+    );
     await onboardingNewMember(
       dao,
       onboarding,
@@ -694,15 +714,166 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
       SHARES
     );
 
-    //Check Guild Bank Balance
-    let guildBalance = await dao.balanceOf(GUILD, ETH_TOKEN);
-    assert.equal(toBN(guildBalance).toString(), "1200000000000000000");
+    //SubGuildKick
+    let memberToKick = newMember;
+    let { kickProposalId } = await guildKick(
+      dao,
+      guildkickContract,
+      memberToKick,
+      member
+    );
 
-    //Check Member Shares & Loot
-    let shares = await dao.nbShares(newMember);
-    assert.equal(shares.toString(), "10000000000000000");
-    let loot = await dao.nbLoot(newMember);
-    assert.equal(loot.toString(), "0");
+    //Vote YES on kick proposal
+    await voting.submitVote(dao.address, kickProposalId, 1, {
+      from: member,
+      gasPrice: toBN("0"),
+    });
+    await advanceTime(10000);
+
+    await guildkickContract.kick(dao.address, memberToKick, kickProposalId, {
+      from: member,
+      gasPrice: toBN("0"),
+    });
+
+    // Member must be inactive after the kick has happened
+    let kickedMember = memberToKick;
+    let activeMember = await dao.isActiveMember(kickedMember, {
+      from: member,
+      gasPrice: toBN("0"),
+    });
+    assert.equal(activeMember.toString(), "false");
+
+    // Submit proposal to onboard new member
+    let newMemberB = accounts[3];
+    let onboardProposalId = await submitNewMemberProposal(
+      member,
+      onboarding,
+      dao,
+      newMemberB,
+      sharePrice,
+      SHARES
+    );
+
+    try {
+      // kicked member attemps to sponsor a new member
+      await sponsorNewMember(
+        onboarding,
+        dao,
+        onboardProposalId,
+        kickedMember,
+        voting
+      );
+      assert.fail(
+        "should not be possible for a kicked member to sponsor a new member"
+      );
+    } catch (e) {
+      assert.equal(e.reason, "onlyMember");
+    }
+  });
+
+  it("should not be possible for a kicked member to vote on in an onboarding proposal", async () => {
+    const member = accounts[5];
+    const newMember = accounts[2];
+
+    let dao = await createDao(member);
+    const onboarding = await getContract(dao, "onboarding", OnboardingContract);
+    const voting = await getContract(dao, "voting", VotingContract);
+    const guildkickContract = await getContract(
+      dao,
+      "guildkick",
+      GuildKickContract
+    );
+    await onboardingNewMember(
+      dao,
+      onboarding,
+      voting,
+      newMember,
+      member,
+      sharePrice,
+      SHARES
+    );
+
+    // Submit guild kick proposal
+    let memberToKick = newMember;
+    let { kickProposalId } = await guildKick(
+      dao,
+      guildkickContract,
+      memberToKick,
+      member
+    );
+
+    // Vote YES on a kick proposal
+    await voting.submitVote(dao.address, kickProposalId, 1, {
+      from: member,
+      gasPrice: toBN("0"),
+    });
+    await advanceTime(10000);
+
+    // Process guild kick proposal
+    await guildkickContract.kick(dao.address, memberToKick, kickProposalId, {
+      from: member,
+      gasPrice: toBN("0"),
+    });
+
+    // Member must be inactive after the kick has happened
+    let kickedMember = memberToKick;
+    let activeMember = await dao.isActiveMember(kickedMember, {
+      from: member,
+      gasPrice: toBN("0"),
+    });
+    assert.equal(activeMember.toString(), "false");
+
+    // Submit proposal to onboard new member
+    let newMemberB = accounts[3];
+    let onboardProposalId = await submitNewMemberProposal(
+      member,
+      onboarding,
+      dao,
+      newMemberB,
+      sharePrice,
+      SHARES
+    );
+
+    //Sponsor the new proposal to start the voting process
+    await onboarding.sponsorProposal(dao.address, onboardProposalId, [], {
+      from: member,
+      gasPrice: toBN("0"),
+    });
+
+    try {
+      // kicked member attemps to vote
+      await voting.submitVote(dao.address, onboardProposalId, 1, {
+        from: kickedMember,
+        gasPrice: toBN("0"),
+      });
+      assert.fail("should not be possible for a kicked member to vote");
+    } catch (e) {
+      assert.equal(e.reason, "onlyMember");
+    }
+  });
+
+  it("should not be possible for a kicked member to sponsor a financing proposal", async () => {
+    const member = accounts[5];
+    const newMember = accounts[2];
+
+    let dao = await createDao(member);
+    const onboarding = await getContract(dao, "onboarding", OnboardingContract);
+    const voting = await getContract(dao, "voting", VotingContract);
+    const guildkickContract = await getContract(
+      dao,
+      "guildkick",
+      GuildKickContract
+    );
+    const financing = await getContract(dao, "financing", FinancingContract);
+    await onboardingNewMember(
+      dao,
+      onboarding,
+      voting,
+      newMember,
+      member,
+      sharePrice,
+      SHARES
+    );
 
     //SubGuildKick
     let memberToKick = newMember;
@@ -712,7 +883,6 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
       memberToKick,
       member
     );
-    assert.equal(kickProposalId.toString(), "1");
 
     //Vote YES on kick proposal
     await voting.submitVote(dao.address, kickProposalId, 1, {
@@ -721,47 +891,195 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     });
     await advanceTime(10000);
 
-    // Member must be active before the kick happens
-    let activeMember = await dao.isActiveMember(memberToKick, {
+    await guildkickContract.kick(dao.address, memberToKick, kickProposalId, {
       from: member,
       gasPrice: toBN("0"),
     });
-    assert.equal(activeMember.toString(), "true");
+
+    // Member must be inactive after the kick has happened
+    let kickedMember = memberToKick;
+    let activeMember = await dao.isActiveMember(kickedMember, {
+      from: member,
+      gasPrice: toBN("0"),
+    });
+    assert.equal(activeMember.toString(), "false");
+
+    // Create Financing Request, the kicked member is the applicant and it is fine for now
+    let requestedAmount = toBN(50000);
+    await financing.createFinancingRequest(
+      dao.address,
+      kickedMember,
+      ETH_TOKEN,
+      requestedAmount,
+      fromUtf8(""),
+      { gasPrice: toBN("0") }
+    );
+
+    let pastEvents = await dao.getPastEvents();
+    let { proposalId } = pastEvents[0].returnValues;
+
+    try {
+      // kicked member attemps to sponsor the financing proposal to get grant
+      await financing.sponsorProposal(dao.address, proposalId, [], {
+        from: kickedMember,
+        gasPrice: toBN("0"),
+      });
+      assert.fail(
+        "should not be possible for a kicked member to sponsor a financing proposal"
+      );
+    } catch (e) {
+      assert.equal(e.reason, "onlyMember");
+    }
+  });
+
+  it("should not be possible for a kicked member to sponsor a financing proposal", async () => {
+    const member = accounts[5];
+    const newMember = accounts[2];
+
+    let dao = await createDao(member);
+    const onboarding = await getContract(dao, "onboarding", OnboardingContract);
+    const voting = await getContract(dao, "voting", VotingContract);
+    const guildkickContract = await getContract(
+      dao,
+      "guildkick",
+      GuildKickContract
+    );
+    const managing = await getContract(dao, "managing", ManagingContract);
+    await onboardingNewMember(
+      dao,
+      onboarding,
+      voting,
+      newMember,
+      member,
+      sharePrice,
+      SHARES
+    );
+
+    //SubGuildKick
+    let memberToKick = newMember;
+    let { kickProposalId } = await guildKick(
+      dao,
+      guildkickContract,
+      memberToKick,
+      member
+    );
+
+    //Vote YES on kick proposal
+    await voting.submitVote(dao.address, kickProposalId, 1, {
+      from: member,
+      gasPrice: toBN("0"),
+    });
+    await advanceTime(10000);
 
     await guildkickContract.kick(dao.address, memberToKick, kickProposalId, {
       from: member,
       gasPrice: toBN("0"),
     });
 
-    // Check Member Shares & Loot, the Shares must be converted to Loot to remove the voting power of the member
-    shares = await dao.nbShares(newMember);
-    assert.equal(shares.toString(), "0");
-    loot = await dao.nbLoot(newMember);
-    assert.equal(loot.toString(), "10000000000000000");
-
-    let kickedMember = memberToKick;
-
     // Member must be inactive after the kick has happened
-    activeMember = await dao.isActiveMember(kickedMember, {
+    let kickedMember = memberToKick;
+    let activeMember = await dao.isActiveMember(kickedMember, {
       from: member,
       gasPrice: toBN("0"),
     });
     assert.equal(activeMember.toString(), "false");
 
+    //Submit a new Bank module proposal
+    let newModuleId = sha3("onboarding");
+    let newModuleAddress = accounts[8];
+
     try {
-      // kicked member attemps to sponsor a new member
-      let newMemberB = accounts[3];
-      await onboardingNewMember(
-        dao,
-        onboarding,
-        voting,
-        newMemberB,
-        kickedMember,
-        sharePrice,
-        SHARES
+      // kicked member attemps to submit a managing proposal
+      await managing.createModuleChangeRequest(
+        dao.address,
+        newModuleId,
+        newModuleAddress,
+        0,
+        { from: kickedMember, gasPrice: toBN("0") }
       );
       assert.fail(
-        "should not be possible for a kicked member to sponsor a new member"
+        "should not be possible for a kicked member to submit a managing proposal"
+      );
+    } catch (e) {
+      assert.equal(e.reason, "onlyMember");
+    }
+  });
+
+  it("should not be possible for a kicked member to sponsor a managing proposal", async () => {
+    const member = accounts[5];
+    const newMember = accounts[2];
+
+    let dao = await createDao(member);
+    const onboarding = await getContract(dao, "onboarding", OnboardingContract);
+    const voting = await getContract(dao, "voting", VotingContract);
+    const guildkickContract = await getContract(
+      dao,
+      "guildkick",
+      GuildKickContract
+    );
+    const managing = await getContract(dao, "managing", ManagingContract);
+    await onboardingNewMember(
+      dao,
+      onboarding,
+      voting,
+      newMember,
+      member,
+      sharePrice,
+      SHARES
+    );
+
+    //SubGuildKick
+    let memberToKick = newMember;
+    let { kickProposalId } = await guildKick(
+      dao,
+      guildkickContract,
+      memberToKick,
+      member
+    );
+
+    //Vote YES on kick proposal
+    await voting.submitVote(dao.address, kickProposalId, 1, {
+      from: member,
+      gasPrice: toBN("0"),
+    });
+    await advanceTime(10000);
+
+    await guildkickContract.kick(dao.address, memberToKick, kickProposalId, {
+      from: member,
+      gasPrice: toBN("0"),
+    });
+
+    // Member must be inactive after the kick has happened
+    let kickedMember = memberToKick;
+    let activeMember = await dao.isActiveMember(kickedMember, {
+      from: member,
+      gasPrice: toBN("0"),
+    });
+    assert.equal(activeMember.toString(), "false");
+
+    //Submit a new Bank module proposal
+    let newModuleId = sha3("onboarding");
+    let newModuleAddress = accounts[3]; //TODO deploy some Banking test contract
+    await managing.createModuleChangeRequest(
+      dao.address,
+      newModuleId,
+      newModuleAddress,
+      0,
+      { from: member, gasPrice: toBN("0") }
+    );
+
+    //Get the new proposal id
+    let pastEvents = await dao.getPastEvents();
+    let { proposalId } = pastEvents[0].returnValues;
+
+    try {
+      // kicked member attemps to sponsor a managing proposal
+      await managing.sponsorProposal(dao.address, proposalId, [], {
+        from: kickedMember,
+        gasPrice: toBN("0"),
+      });
+      assert.fail(
+        "should not be possible for a kicked member to sponsor a managing proposal"
       );
     } catch (e) {
       assert.equal(e.reason, "onlyMember");

--- a/test/adapters/guildkick.test.js
+++ b/test/adapters/guildkick.test.js
@@ -38,7 +38,7 @@ const {
 } = require("../../utils/DaoFactory.js");
 
 contract("LAOLAND - GuildKick Adapter", async (accounts) => {
-  submitNewMemberProposal = async (
+  const submitNewMemberProposal = async (
     member,
     onboarding,
     dao,
@@ -63,7 +63,13 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     return proposalId;
   };
 
-  sponsorNewMember = async (onboarding, dao, proposalId, sponsor, voting) => {
+  const sponsorNewMember = async (
+    onboarding,
+    dao,
+    proposalId,
+    sponsor,
+    voting
+  ) => {
     await onboarding.sponsorProposal(dao.address, proposalId, [], {
       from: sponsor,
       gasPrice: toBN("0"),
@@ -75,7 +81,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     await advanceTime(10000);
   };
 
-  onboardingNewMember = async (
+  const onboardingNewMember = async (
     dao,
     onboarding,
     voting,
@@ -101,7 +107,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     });
   };
 
-  guildKick = async (dao, guildkickContract, memberToKick, sender) => {
+  const guildKick = async (dao, guildkickContract, memberToKick, sender) => {
     await guildkickContract.submitKickProposal(
       dao.address,
       memberToKick,

--- a/test/adapters/guildkick.test.js
+++ b/test/adapters/guildkick.test.js
@@ -114,7 +114,12 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     });
   };
 
-  const guildKick = async (dao, guildkickContract, memberToKick, sender) => {
+  const guildKickProposal = async (
+    dao,
+    guildkickContract,
+    memberToKick,
+    sender
+  ) => {
     await guildkickContract.submitKickProposal(
       dao.address,
       memberToKick,
@@ -166,7 +171,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     //SubGuildKick
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKick(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -188,7 +193,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     });
     assert.equal(activeMember.toString(), "true");
 
-    await guildkickContract.kick(dao.address, memberToKick, kickProposalId, {
+    await guildkickContract.kick(dao.address, kickProposalId, {
       from: member,
       gasPrice: toBN("0"),
     });
@@ -221,7 +226,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     // Non member attemps to submit a guild kick proposal
     try {
       let memberToKick = member;
-      await guildKick(dao, guildkickContract, memberToKick, nonMember);
+      await guildKickProposal(dao, guildkickContract, memberToKick, nonMember);
       assert.fail(
         "should not be possible a non-member to submit a guild kick proposal"
       );
@@ -254,7 +259,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Start a new kick poposal
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKick(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -269,7 +274,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     await advanceTime(10000);
 
     // The member gets kicked out of the DAO
-    await guildkickContract.kick(dao.address, memberToKick, kickProposalId, {
+    await guildkickContract.kick(dao.address, kickProposalId, {
       from: member,
       gasPrice: toBN("0"),
     });
@@ -277,7 +282,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     try {
       // The kicked member which is now inactive attemps to submit a kick proposal
       // to kick the member that started the previous guild kick
-      await guildkickContract.kick(dao.address, member, kickProposalId, {
+      await guildkickContract.kick(dao.address, kickProposalId, {
         from: memberToKick,
         gasPrice: toBN("0"),
       });
@@ -287,7 +292,6 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     } catch (e) {
       assert.equal(e.reason, "onlyMember");
     }
-    //TODO: call other adapters to ensure the kicked member can't do anything else
   });
 
   it("should not be possible for a non-member to process a kick proposal", async () => {
@@ -315,7 +319,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Start a new kick poposal
     let memberToKick = newMemberA;
-    let { kickProposalId } = await guildKick(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -333,7 +337,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     try {
       // A non-member of the DAO attemps to process a kick proposal
-      await guildkickContract.kick(dao.address, memberToKick, kickProposalId, {
+      await guildkickContract.kick(dao.address, kickProposalId, {
         from: nonMember,
         gasPrice: toBN("0"),
       });
@@ -370,7 +374,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Start a new kick poposal
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKick(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -385,7 +389,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     await advanceTime(10000);
 
     // The member gets kicked out of the DAO
-    await guildkickContract.kick(dao.address, memberToKick, kickProposalId, {
+    await guildkickContract.kick(dao.address, kickProposalId, {
       from: member,
       gasPrice: toBN("0"),
     });
@@ -393,7 +397,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     try {
       // The kicked member which is now inactive attemps to submit a kick proposal
       // to kick the member that started the previous guild kick
-      await guildkickContract.kick(dao.address, member, kickProposalId, {
+      await guildkickContract.kick(dao.address, kickProposalId, {
         from: memberToKick,
         gasPrice: toBN("0"),
       });
@@ -430,7 +434,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Start a new kick poposal
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKick(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -445,14 +449,14 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     await advanceTime(10000);
 
     // The member gets kicked out of the DAO
-    await guildkickContract.kick(dao.address, memberToKick, kickProposalId, {
+    await guildkickContract.kick(dao.address, kickProposalId, {
       from: member,
       gasPrice: toBN("0"),
     });
 
     try {
       // The member attempts to process the same proposal again
-      await guildkickContract.kick(dao.address, memberToKick, kickProposalId, {
+      await guildkickContract.kick(dao.address, kickProposalId, {
         from: member,
         gasPrice: toBN("0"),
       });
@@ -489,7 +493,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Start a new kick poposal
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKick(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -506,20 +510,15 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     try {
       // The member attempts to process the same proposal again
       let invalidKickProposalId = 89;
-      await guildkickContract.kick(
-        dao.address,
-        memberToKick,
-        invalidKickProposalId,
-        {
-          from: member,
-          gasPrice: toBN("0"),
-        }
-      );
+      await guildkickContract.kick(dao.address, invalidKickProposalId, {
+        from: member,
+        gasPrice: toBN("0"),
+      });
       assert.fail(
         "should not be possible to process a proposal that does not exist"
       );
     } catch (e) {
-      assert.equal(e.reason, "invalid kick proposal");
+      assert.equal(e.reason, "guild kick already completed or does not exist");
     }
   });
 
@@ -548,7 +547,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Start a new kick poposal
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKick(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -563,17 +562,22 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     await advanceTime(10000);
 
     // The member gets kicked out and become inactive
-    await guildkickContract.kick(dao.address, memberToKick, kickProposalId, {
+    await guildkickContract.kick(dao.address, kickProposalId, {
       from: member,
       gasPrice: toBN("0"),
     });
 
     // The remaining members accidentaly submit another kick proposal for an inactive member
     // A member that was already kicked out
-    let res = await guildKick(dao, guildkickContract, memberToKick, member);
+    let res = await guildKickProposal(
+      dao,
+      guildkickContract,
+      memberToKick,
+      member
+    );
     kickProposalId = res.kickProposalId;
     try {
-      await guildkickContract.kick(dao.address, memberToKick, kickProposalId, {
+      await guildkickContract.kick(dao.address, kickProposalId, {
         from: member,
         gasPrice: toBN("0"),
       });
@@ -610,7 +614,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Start a new kick poposal
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKick(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -626,7 +630,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     try {
       // The member attemps to process the kick proposal that did not pass
-      await guildkickContract.kick(dao.address, memberToKick, kickProposalId, {
+      await guildkickContract.kick(dao.address, kickProposalId, {
         from: member,
         gasPrice: toBN("0"),
       });
@@ -664,7 +668,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Start a new kick poposal to kick out the advisor
     let memberToKick = advisor;
-    let { kickProposalId } = await guildKick(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -680,7 +684,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     try {
       // The member attemps to process the kick proposal, but the Advisor does not have any SHARES, only LOOT
-      await guildkickContract.kick(dao.address, memberToKick, kickProposalId, {
+      await guildkickContract.kick(dao.address, kickProposalId, {
         from: member,
         gasPrice: toBN("0"),
       });
@@ -716,7 +720,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     //SubGuildKick
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKick(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -730,7 +734,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     });
     await advanceTime(10000);
 
-    await guildkickContract.kick(dao.address, memberToKick, kickProposalId, {
+    await guildkickContract.kick(dao.address, kickProposalId, {
       from: member,
       gasPrice: toBN("0"),
     });
@@ -795,7 +799,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Submit guild kick proposal
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKick(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -810,7 +814,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     await advanceTime(10000);
 
     // Process guild kick proposal
-    await guildkickContract.kick(dao.address, memberToKick, kickProposalId, {
+    await guildkickContract.kick(dao.address, kickProposalId, {
       from: member,
       gasPrice: toBN("0"),
     });
@@ -877,7 +881,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     //SubGuildKick
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKick(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -891,7 +895,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     });
     await advanceTime(10000);
 
-    await guildkickContract.kick(dao.address, memberToKick, kickProposalId, {
+    await guildkickContract.kick(dao.address, kickProposalId, {
       from: member,
       gasPrice: toBN("0"),
     });
@@ -957,7 +961,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     //SubGuildKick
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKick(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -971,7 +975,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     });
     await advanceTime(10000);
 
-    await guildkickContract.kick(dao.address, memberToKick, kickProposalId, {
+    await guildkickContract.kick(dao.address, kickProposalId, {
       from: member,
       gasPrice: toBN("0"),
     });
@@ -1030,7 +1034,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     //SubGuildKick
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKick(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -1044,7 +1048,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     });
     await advanceTime(10000);
 
-    await guildkickContract.kick(dao.address, memberToKick, kickProposalId, {
+    await guildkickContract.kick(dao.address, kickProposalId, {
       from: member,
       gasPrice: toBN("0"),
     });

--- a/test/adapters/guildkick.test.js
+++ b/test/adapters/guildkick.test.js
@@ -1,0 +1,162 @@
+/**
+MIT License
+
+Copyright (c) 2020 Openlaw
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+const { toUtf8 } = require("ethereumjs-util");
+const {
+  sha3,
+  toBN,
+  fromUtf8,
+  advanceTime,
+  createDao,
+  sharePrice,
+  GUILD,
+  ETH_TOKEN,
+  SHARES,
+  OnboardingContract,
+  VotingContract,
+  GuildKickContract,
+} = require("../../utils/DaoFactory.js");
+
+contract("LAOLAND - GuildKick Adapter", async (accounts) => {
+  submitNewMemberProposal = async (onboarding, dao, newMember, sharePrice) => {
+    const myAccount = accounts[1];
+
+    await onboarding.onboard(
+      dao.address,
+      newMember,
+      SHARES,
+      sharePrice.mul(toBN(100)),
+      {
+        from: myAccount,
+        value: sharePrice.mul(toBN(100)),
+        gasPrice: toBN("0"),
+      }
+    );
+    //Get the new proposal id
+    let pastEvents = await dao.getPastEvents();
+    let { proposalId } = pastEvents[0].returnValues;
+    return proposalId;
+  };
+
+  sponsorNewMember = async (onboarding, dao, proposalId, member, voting) => {
+    await onboarding.sponsorProposal(dao.address, proposalId, [], {
+      from: member,
+      gasPrice: toBN("0"),
+    });
+    await voting.submitVote(dao.address, proposalId, 1, {
+      from: member,
+      gasPrice: toBN("0"),
+    });
+    await advanceTime(10000);
+  };
+
+  guildKick = async (dao, memberToKick, sender) => {
+    let guildkickAddress = await dao.getAdapterAddress(sha3("guildkick"));
+    let guildkickContract = await GuildKickContract.at(guildkickAddress);
+    await guildkickContract.submitKickProposal(
+      dao.address,
+      memberToKick,
+      fromUtf8(""),
+      {
+        from: sender,
+        gasPrice: toBN("0"),
+      }
+    );
+
+    //Get the new proposal id
+    let pastEvents = await dao.getPastEvents();
+    let { proposalId } = pastEvents[0].returnValues;
+
+    return { guildkickContract, kickProposalId: proposalId };
+  };
+
+  it("should be possible to kick a DAO member", async () => {
+    const myAccount = accounts[1];
+    const newMember = accounts[2];
+
+    let dao = await createDao(myAccount);
+
+    //Add funds to the Guild Bank after sposoring a member to join the Guild
+    const onboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
+    const onboarding = await OnboardingContract.at(onboardingAddress);
+
+    const votingAddress = await dao.getAdapterAddress(sha3("voting"));
+    const voting = await VotingContract.at(votingAddress);
+
+    let newProposalId = await submitNewMemberProposal(
+      onboarding,
+      dao,
+      newMember,
+      sharePrice
+    );
+    assert.equal(newProposalId.toString(), "0");
+
+    //Sponsor the new proposal, vote and process it
+    await sponsorNewMember(onboarding, dao, newProposalId, myAccount, voting);
+    await onboarding.processProposal(dao.address, newProposalId, {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
+
+    //Check Guild Bank Balance
+    let guildBalance = await dao.balanceOf(GUILD, ETH_TOKEN);
+    assert.equal(toBN(guildBalance).toString(), "12000000000000000000");
+
+    //Check Member Shares & Loot
+    let shares = await dao.nbShares(newMember);
+    assert.equal(shares.toString(), "100000000000000000");
+    let loot = await dao.nbLoot(newMember);
+    assert.equal(loot.toString(), "0");
+
+    //SubGuildKick
+    let memberToKick = newMember;
+    let { guildkickContract, kickProposalId } = await guildKick(
+      dao,
+      memberToKick,
+      myAccount
+    );
+    assert.equal(kickProposalId.toString(), "1");
+
+    //Vote YES on kick proposal
+    await voting.submitVote(dao.address, kickProposalId, 1, {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
+    await advanceTime(10000);
+
+    await guildkickContract.kick(dao.address, memberToKick, kickProposalId, {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
+
+    // Check Member Shares & Loot, the Shares must be converted to Loot to remove the voting power of the member
+    shares = await dao.nbShares(newMember);
+    assert.equal(shares.toString(), "0");
+    loot = await dao.nbLoot(newMember);
+    assert.equal(loot.toString(), "100000000000000000");
+
+    // TODO Check if the member is in jail
+
+    // TODO try to access other functions
+  });
+});

--- a/test/adapters/guildkick.test.js
+++ b/test/adapters/guildkick.test.js
@@ -144,6 +144,13 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     });
     await advanceTime(10000);
 
+    // Member must be active before the kick happens
+    let activeMember = await dao.isActiveMember(memberToKick, {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
+    assert.equal(activeMember.toString(), "true");
+
     await guildkickContract.kick(dao.address, memberToKick, kickProposalId, {
       from: myAccount,
       gasPrice: toBN("0"),
@@ -155,8 +162,11 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     loot = await dao.nbLoot(newMember);
     assert.equal(loot.toString(), "100000000000000000");
 
-    // TODO Check if the member is in jail
-
-    // TODO try to access other functions
+    // Member must be inactive after the kick has happened
+    activeMember = await dao.isActiveMember(memberToKick, {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
+    assert.equal(activeMember.toString(), "false");
   });
 });

--- a/utils/DaoFactory.js
+++ b/utils/DaoFactory.js
@@ -27,119 +27,224 @@ const toWei = web3.utils.toWei;
 const fromUtf8 = web3.utils.fromUtf8;
 
 const GUILD = "0x000000000000000000000000000000000000dead";
-const TOTAL =  "0x000000000000000000000000000000000000babe";
+const TOTAL = "0x000000000000000000000000000000000000babe";
 const SHARES = "0x00000000000000000000000000000000000FF1CE";
-const LOOT =   "0x00000000000000000000000000000000B105F00D";
+const LOOT = "0x00000000000000000000000000000000B105F00D";
 const ETH_TOKEN = "0x0000000000000000000000000000000000000000";
 const DAI_TOKEN = "0x95b58a6bff3d14b7db2f5cb5f0ad413dc2940658";
 
-const numberOfShares = toBN('1000000000000000');
-const sharePrice = toBN(toWei("120", 'finney'));
-const remaining = sharePrice.sub(toBN('50000000000000'));
+const numberOfShares = toBN("1000000000000000");
+const sharePrice = toBN(toWei("120", "finney"));
+const remaining = sharePrice.sub(toBN("50000000000000"));
 
 const OLTokenContract = artifacts.require("./test/OLT");
 
-const FlagHelperLib = artifacts.require('./helpers/FlagHelper');
-const DaoFactory = artifacts.require('./core/DaoFactory');
+const FlagHelperLib = artifacts.require("./helpers/FlagHelper");
+const DaoFactory = artifacts.require("./core/DaoFactory");
 const DaoRegistry = artifacts.require("./core/DaoRegistry");
-const VotingContract = artifacts.require('./adapters/VotingContract');
-const ManagingContract = artifacts.require('./adapter/ManagingContract');
-const FinancingContract = artifacts.require('./adapter/FinancingContract');
-const RagequitContract = artifacts.require('./adapters/RagequitContract');
-const OnboardingContract = artifacts.require('./adapters/OnboardingContract');
+const VotingContract = artifacts.require("./adapters/VotingContract");
+const ManagingContract = artifacts.require("./adapter/ManagingContract");
+const FinancingContract = artifacts.require("./adapter/FinancingContract");
+const RagequitContract = artifacts.require("./adapters/RagequitContract");
+const GuildKickContract = artifacts.require("./adapters/GuildKickContract");
+const OnboardingContract = artifacts.require("./adapters/OnboardingContract");
 
 async function prepareSmartContracts() {
-    let voting = await VotingContract.new();
-    let ragequit = await RagequitContract.new();
-    let managing = await ManagingContract.new();
-    let financing = await FinancingContract.new();
-    let onboarding = await OnboardingContract.new();
-    let daoFactory = await DaoFactory.new();
+  let voting = await VotingContract.new();
+  let ragequit = await RagequitContract.new();
+  let managing = await ManagingContract.new();
+  let financing = await FinancingContract.new();
+  let onboarding = await OnboardingContract.new();
+  let guildkick = await GuildKickContract.new();
+  let daoFactory = await DaoFactory.new();
 
-    return {
-      voting,
-      ragequit,
-      managing,
-      financing,
-      onboarding,
-      daoFactory
-    };
-  }
+  return {
+    voting,
+    ragequit,
+    guildkick,
+    managing,
+    financing,
+    onboarding,
+    daoFactory,
+  };
+}
 
-async function addDefaultAdapters(dao, unitPrice=sharePrice, nbShares=numberOfShares, votingPeriod=10, gracePeriod=1, tokenAddr = ETH_TOKEN) {
-    const {voting, ragequit, managing, financing, onboarding, daoFactory} = await prepareSmartContracts();
+async function addDefaultAdapters(
+  dao,
+  unitPrice = sharePrice,
+  nbShares = numberOfShares,
+  votingPeriod = 10,
+  gracePeriod = 1,
+  tokenAddr = ETH_TOKEN
+) {
+  const {
+    voting,
+    ragequit,
+    guildkick,
+    managing,
+    financing,
+    onboarding,
+    daoFactory,
+  } = await prepareSmartContracts();
 
-    /**
+  /**
      * EXISTS, SPONSORED, PROCESSED, JAILED,
         ADD_ADAPTER,REMOVE_ADAPTER,JAIL_MEMBER, UNJAIL_MEMBER, EXECUTE, SUBMIT_PROPOSAL, SPONSOR_PROPOSAL, PROCESS_PROPOSAL, 
         UPDATE_DELEGATE_KEY, REGISTER_NEW_TOKEN, REGISTER_NEW_INTERNAL_TOKEN, ADD_TO_BALANCE,SUB_FROM_BALANCE, INTERNAL_TRANSFER
      */
 
-    await daoFactory.addAdapters(
-      dao.address,
-      [
-        entry("voting", voting, {}),
-        entry("ragequit", ragequit, {SUB_FROM_BALANCE: true, JAIL_MEMBER: true, UNJAIL_MEMBER: true, INTERNAL_TRANSFER: true}),
-        entry("managing", managing, {SUBMIT_PROPOSAL: true, PROCESS_PROPOSAL: true, SPONSOR_PROPOSAL: true, REMOVE_ADAPTER: true, ADD_ADAPTER: true}),
-        entry("financing", financing, {SUBMIT_PROPOSAL:true, SPONSOR_PROPOSAL: true, PROCESS_PROPOSAL: true, ADD_TO_BALANCE:true , SUB_FROM_BALANCE:true}),
-        entry("onboarding", onboarding, {SUBMIT_PROPOSAL:true, SPONSOR_PROPOSAL: true, PROCESS_PROPOSAL: true, ADD_TO_BALANCE:true, UPDATE_DELEGATE_KEY: true})
-    ])
-    
-    await onboarding.configureDao(dao.address, SHARES, unitPrice, nbShares, tokenAddr);
-    await onboarding.configureDao(dao.address, LOOT, unitPrice, nbShares, tokenAddr);
-    await voting.configureDao(dao.address, votingPeriod, gracePeriod);
+  await daoFactory.addAdapters(dao.address, [
+    entry("voting", voting, {}),
+    entry("ragequit", ragequit, {
+      SUB_FROM_BALANCE: true,
+      JAIL_MEMBER: true,
+      UNJAIL_MEMBER: true,
+      INTERNAL_TRANSFER: true,
+    }),
+    entry("guildkick", guildkick, {
+      SUBMIT_PROPOSAL: true,
+      PROCESS_PROPOSAL: true,
+      SPONSOR_PROPOSAL: true,
+      SUB_FROM_BALANCE: true,
+      ADD_TO_BALANCE: true,
+      JAIL_MEMBER: true,
+      INTERNAL_TRANSFER: true,
+    }),
+    entry("managing", managing, {
+      SUBMIT_PROPOSAL: true,
+      PROCESS_PROPOSAL: true,
+      SPONSOR_PROPOSAL: true,
+      REMOVE_ADAPTER: true,
+      ADD_ADAPTER: true,
+    }),
+    entry("financing", financing, {
+      SUBMIT_PROPOSAL: true,
+      SPONSOR_PROPOSAL: true,
+      PROCESS_PROPOSAL: true,
+      ADD_TO_BALANCE: true,
+      SUB_FROM_BALANCE: true,
+    }),
+    entry("onboarding", onboarding, {
+      SUBMIT_PROPOSAL: true,
+      SPONSOR_PROPOSAL: true,
+      PROCESS_PROPOSAL: true,
+      ADD_TO_BALANCE: true,
+      UPDATE_DELEGATE_KEY: true,
+    }),
+  ]);
 
-    return dao;
+  await onboarding.configureDao(
+    dao.address,
+    SHARES,
+    unitPrice,
+    nbShares,
+    tokenAddr
+  );
+  await onboarding.configureDao(
+    dao.address,
+    LOOT,
+    unitPrice,
+    nbShares,
+    tokenAddr
+  );
+  await voting.configureDao(dao.address, votingPeriod, gracePeriod);
+
+  return dao;
 }
 
-async function createDao(senderAccount, unitPrice=sharePrice, nbShares=numberOfShares, votingPeriod=10, gracePeriod=1, tokenAddr = ETH_TOKEN) {
-    let lib = await FlagHelperLib.new();
-    await DaoRegistry.link("FlagHelper", lib.address);
-    let dao = await DaoRegistry.new({ from: senderAccount, gasPrice: toBN("0") });
-    let receipt = await web3.eth.getTransactionReceipt(dao.transactionHash);
-    console.log('gas used for dao:', receipt && receipt.gasUsed);
-    await addDefaultAdapters(dao, unitPrice, nbShares, votingPeriod, gracePeriod, tokenAddr);
-    await dao.finalizeDao();
-    return dao;
+async function createDao(
+  senderAccount,
+  unitPrice = sharePrice,
+  nbShares = numberOfShares,
+  votingPeriod = 10,
+  gracePeriod = 1,
+  tokenAddr = ETH_TOKEN
+) {
+  let lib = await FlagHelperLib.new();
+  await DaoRegistry.link("FlagHelper", lib.address);
+  let dao = await DaoRegistry.new({ from: senderAccount, gasPrice: toBN("0") });
+  let receipt = await web3.eth.getTransactionReceipt(dao.transactionHash);
+  console.log("gas used for dao:", receipt && receipt.gasUsed);
+  await addDefaultAdapters(
+    dao,
+    unitPrice,
+    nbShares,
+    votingPeriod,
+    gracePeriod,
+    tokenAddr
+  );
+  await dao.finalizeDao();
+  return dao;
 }
 
 function entry(name, contract, flags) {
-  const values = [flags.EXISTS, flags.SPONSORED, flags.PROCESSED, flags.JAILED,
-  flags.ADD_ADAPTER,flags.REMOVE_ADAPTER,flags.JAIL_MEMBER, flags.UNJAIL_MEMBER, flags.EXECUTE, flags.SUBMIT_PROPOSAL, flags.SPONSOR_PROPOSAL, flags.PROCESS_PROPOSAL, 
-  flags.UPDATE_DELEGATE_KEY, flags.REGISTER_NEW_TOKEN, flags.REGISTER_NEW_INTERNAL_TOKEN, flags.ADD_TO_BALANCE,flags.SUB_FROM_BALANCE, flags.INTERNAL_TRANSFER, flags.WITHDRAW_PROPOSAL, flags.WITHDRAWN]
+  const values = [
+    flags.EXISTS,
+    flags.SPONSORED,
+    flags.PROCESSED,
+    flags.JAILED,
+    flags.ADD_ADAPTER,
+    flags.REMOVE_ADAPTER,
+    flags.JAIL_MEMBER,
+    flags.UNJAIL_MEMBER,
+    flags.EXECUTE,
+    flags.SUBMIT_PROPOSAL,
+    flags.SPONSOR_PROPOSAL,
+    flags.PROCESS_PROPOSAL,
+    flags.UPDATE_DELEGATE_KEY,
+    flags.REGISTER_NEW_TOKEN,
+    flags.REGISTER_NEW_INTERNAL_TOKEN,
+    flags.ADD_TO_BALANCE,
+    flags.SUB_FROM_BALANCE,
+    flags.INTERNAL_TRANSFER,
+    flags.WITHDRAW_PROPOSAL,
+    flags.WITHDRAWN,
+  ];
 
-  const acl = values.map((v, idx) => v ? 2 ** idx : 0).reduce((a, b) => a +  b);
+  const acl = values
+    .map((v, idx) => (v ? 2 ** idx : 0))
+    .reduce((a, b) => a + b);
 
   return {
     id: sha3(name),
     addr: contract.address,
-    flags: acl
-  }
+    flags: acl,
+  };
 }
 
 async function advanceTime(time) {
-    await new Promise((resolve, reject) => {
-        web3.currentProvider.send({
-        jsonrpc: '2.0',
-        method: 'evm_increaseTime',
+  await new Promise((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        jsonrpc: "2.0",
+        method: "evm_increaseTime",
         params: [time],
-        id: new Date().getTime()
-        }, (err, result) => {
-        if (err) { return reject(err) }
-        return resolve(result)
-        })
-    });
+        id: new Date().getTime(),
+      },
+      (err, result) => {
+        if (err) {
+          return reject(err);
+        }
+        return resolve(result);
+      }
+    );
+  });
 
-    await new Promise((resolve, reject) => {
-        web3.currentProvider.send({
-            jsonrpc: '2.0',
-            method: 'evm_mine',
-            id: new Date().getTime()
-        }, (err, result) => {
-            if (err) { return reject(err) }
-            return resolve(result)
-        })
-    });
+  await new Promise((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        jsonrpc: "2.0",
+        method: "evm_mine",
+        id: new Date().getTime(),
+      },
+      (err, result) => {
+        if (err) {
+          return reject(err);
+        }
+        return resolve(result);
+      }
+    );
+  });
 }
 
 async function getContract(dao, id, contractFactory) {
@@ -175,5 +280,6 @@ module.exports = {
   ManagingContract,
   FinancingContract,
   RagequitContract,
-  OnboardingContract
+  GuildKickContract,
+  OnboardingContract,
 };


### PR DESCRIPTION
Closes #56

Scenario:
As a DAO member I want to be able to submit a guild kick proposal to indicate a member that should be kicked out of the DAO. 
If the guild kick proposal pass, the member has its shares converted to LOOT and is also moved to jail. A member in jail is considered an inactive member that has no voting power, and can not perform any other operations within the DAO.

- [x] Guild Kick proposal
- [x] Vote on Guild Kick Proposal
- [x] Process the Guild Kick Proposal and perform safe checks
- [x] Put the member in Jail (wont implement the conditional: until all proposals voted YES on are processed)
- [x] Convert all shares to loot when the member is in jail (to remove the voting power)
- [x] Guild Kick Tests
   - [x] should be possible to kick a DAO member
   - [x] should not be possible for a non-member to submit a guild kick proposal
   - [x] should not be possible for a non-member to process a kick proposal
   - [x] should not be possible to process a kick proposal that was already processed
   - [x] should not be possible to process a kick proposal that does not exist
   - [x] should not be possible to process a kick proposal for a non active member
   - [x] should not be possible to process a kick proposal if the voting did not pass
   - [x] should not be possible to process a kick proposal if the member to kick does not have any shares
   - [x] should not be possible for a non-active/jailed member to submit a guild kick proposal
   - [x] should not be possible for a non-active/jailed member to process a kick proposal
   - [x] should not be possible for a non-active/jailed member to vote (onchain voting) on a proposal
   - [x] should not be possible for a non-active/jailed member to sponsor an onboarding proposal
   - [x] should not be possible for a non-active/jailed member to sponsor a financial proposal
   - [x] should not be possible for a non-active/jailed member to submit a managing proposal
   - [x] should not be possible for a non-active/jailed member to sponsor a managing proposal

Notes:
- The guild kick does not take into consideration if the target member has voted YES/NO on any open proposals. In other words, we are not forcing the member to stay in the DAO until the proposals he/she voted on are processed. We might add that later on, but due to the offchain voting we are not tracking the votes of each member.  
- A kicked member is allowed to submit financing proposals, and be the beneficiary at the same time. However, it is not possible for a kicked member to sponsor or vote on any proposals.
