### PR TITLE
GH-57 - Rage Kick operation

### DIFF
--- a/contracts/adapters/GuildKick.sol
+++ b/contracts/adapters/GuildKick.sol
@@ -8,6 +8,7 @@ import "../guards/MemberGuard.sol";
 import "./interfaces/IGuildKick.sol";
 import "../utils/SafeMath.sol";
 import "../adapters/interfaces/IVoting.sol";
+import "../helpers/FairShareHelper.sol";
 
 /**
 MIT License
@@ -147,7 +148,7 @@ contract GuildKickContract is IGuildKick, DaoConstants, MemberGuard {
         uint256 initialTotalShares = kick.initialTotalShares;
         for (uint256 i = currentIndex; i < maxIndex; i++) {
             address token = dao.getToken(i);
-            uint256 amountToRagequit = _fairShare(
+            uint256 amountToRagequit = FairShareHelper.calc(
                 dao.balanceOf(GUILD, token),
                 kick.shares,
                 initialTotalShares
@@ -172,20 +173,4 @@ contract GuildKickContract is IGuildKick, DaoConstants, MemberGuard {
         }
     }
 
-    function _fairShare(
-        uint256 balance,
-        uint256 shares,
-        uint256 _totalShares
-    ) internal pure returns (uint256) {
-        require(_totalShares != 0, "total shares should not be 0");
-        if (balance == 0) {
-            return 0;
-        }
-        uint256 prod = balance * shares;
-        if (prod / balance == shares) {
-            // no overflow in multiplication above?
-            return prod / _totalShares;
-        }
-        return (balance / _totalShares) * shares;
-    }
 }

--- a/contracts/adapters/GuildKick.sol
+++ b/contracts/adapters/GuildKick.sol
@@ -122,11 +122,11 @@ contract GuildKickContract is IGuildKick, DaoConstants, MemberGuard {
         dao.processProposal(proposalId);
     }
 
-    function rageKick(DaoRegistry dao, uint64 proposalId, uint256 toIndex) 
-        external
-        override
-        onlyMember(dao) 
-    {
+    function rageKick(
+        DaoRegistry dao,
+        uint64 proposalId,
+        uint256 toIndex
+    ) external override onlyMember(dao) {
         GuildKick storage kick = kicks[proposalId];
         // If does not exist or is not DONE we expect it to fail
         require(
@@ -175,5 +175,4 @@ contract GuildKickContract is IGuildKick, DaoConstants, MemberGuard {
             dao.unjailMember(kickedMember);
         }
     }
-
 }

--- a/contracts/adapters/GuildKick.sol
+++ b/contracts/adapters/GuildKick.sol
@@ -36,7 +36,7 @@ SOFTWARE.
 
 contract GuildKickContract is IGuildKick, DaoConstants, MemberGuard {
     using SafeMath for uint256;
-    enum GuildKickStatus {IN_PROGRESS, DONE}
+    enum GuildKickStatus {NOT_STARTED, IN_PROGRESS, DONE}
 
     struct GuildKick {
         address memberToKick;
@@ -44,7 +44,6 @@ contract GuildKickContract is IGuildKick, DaoConstants, MemberGuard {
         uint256 sharesToBurn;
         uint256 initialTotalShares;
         bytes data;
-        bool exists;
         uint256 currentIndex;
         uint256 blockNumber;
     }
@@ -72,7 +71,6 @@ contract GuildKickContract is IGuildKick, DaoConstants, MemberGuard {
             dao.balanceOf(memberToKick, SHARES),
             dao.balanceOf(TOTAL, SHARES),
             data,
-            true,
             0,
             block.number
         );
@@ -94,8 +92,7 @@ contract GuildKickContract is IGuildKick, DaoConstants, MemberGuard {
     {
         GuildKick storage kick = kicks[proposalId];
         // If it does not exist or is not in progress we expect it to fail
-        require(
-            kick.exists && kick.status == GuildKickStatus.IN_PROGRESS,
+        require(kick.status == GuildKickStatus.IN_PROGRESS,
             "guild kick already completed or does not exist"
         );
 
@@ -129,8 +126,7 @@ contract GuildKickContract is IGuildKick, DaoConstants, MemberGuard {
     ) external override onlyMember(dao) {
         GuildKick storage kick = kicks[proposalId];
         // If does not exist or is not DONE we expect it to fail
-        require(
-            kick.exists && kick.status == GuildKickStatus.DONE,
+        require(kick.status == GuildKickStatus.DONE,
             "guild kick not completed or does not exist"
         );
 

--- a/contracts/adapters/GuildKick.sol
+++ b/contracts/adapters/GuildKick.sol
@@ -92,7 +92,8 @@ contract GuildKickContract is IGuildKick, DaoConstants, MemberGuard {
     {
         GuildKick storage kick = kicks[proposalId];
         // If it does not exist or is not in progress we expect it to fail
-        require(kick.status == GuildKickStatus.IN_PROGRESS,
+        require(
+            kick.status == GuildKickStatus.IN_PROGRESS,
             "guild kick already completed or does not exist"
         );
 
@@ -126,7 +127,8 @@ contract GuildKickContract is IGuildKick, DaoConstants, MemberGuard {
     ) external override onlyMember(dao) {
         GuildKick storage kick = kicks[proposalId];
         // If does not exist or is not DONE we expect it to fail
-        require(kick.status == GuildKickStatus.DONE,
+        require(
+            kick.status == GuildKickStatus.DONE,
             "guild kick not completed or does not exist"
         );
 

--- a/contracts/adapters/Ragequit.sol
+++ b/contracts/adapters/Ragequit.sol
@@ -7,6 +7,7 @@ import "../core/DaoRegistry.sol";
 import "../guards/MemberGuard.sol";
 import "./interfaces/IRagequit.sol";
 import "../utils/SafeMath.sol";
+import "../helpers/FairShareHelper.sol";
 
 /**
 MIT License
@@ -129,7 +130,7 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
         uint256 blockNumber = ragequit.blockNumber;
         for (uint256 i = currentIndex; i < maxIndex; i++) {
             address token = dao.getToken(i);
-            uint256 amountToRagequit = _fairShare(
+            uint256 amountToRagequit = FairShareHelper.calc(
                 dao.getPriorAmount(GUILD, token, blockNumber),
                 sharesAndLootToBurn,
                 initialTotalSharesAndLoot
@@ -155,20 +156,4 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
         }
     }
 
-    function _fairShare(
-        uint256 balance,
-        uint256 shares,
-        uint256 _totalShares
-    ) internal pure returns (uint256) {
-        require(_totalShares != 0, "total shares should not be 0");
-        if (balance == 0) {
-            return 0;
-        }
-        uint256 prod = balance * shares;
-        if (prod / balance == shares) {
-            // no overflow in multiplication above?
-            return prod / _totalShares;
-        }
-        return (balance / _totalShares) * shares;
-    }
 }

--- a/contracts/adapters/Ragequit.sol
+++ b/contracts/adapters/Ragequit.sol
@@ -155,5 +155,4 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
             dao.unjailMember(memberAddr);
         }
     }
-
 }

--- a/contracts/adapters/interfaces/IGuildKick.sol
+++ b/contracts/adapters/interfaces/IGuildKick.sol
@@ -37,5 +37,9 @@ interface IGuildKick {
 
     function guildKick(DaoRegistry dao, uint64 proposalId) external;
 
-    function rageKick(DaoRegistry dao, uint64 proposalId, uint256 toIndex) external;
+    function rageKick(
+        DaoRegistry dao,
+        uint64 proposalId,
+        uint256 toIndex
+    ) external;
 }

--- a/contracts/adapters/interfaces/IGuildKick.sol
+++ b/contracts/adapters/interfaces/IGuildKick.sol
@@ -35,5 +35,7 @@ interface IGuildKick {
         bytes calldata data
     ) external returns (uint256);
 
-    function kick(DaoRegistry dao, uint64 proposalId) external;
+    function guildKick(DaoRegistry dao, uint64 proposalId) external;
+
+    function rageKick(DaoRegistry dao, uint64 proposalId, uint256 toIndex) external;
 }

--- a/contracts/helpers/FairShareHelper.sol
+++ b/contracts/helpers/FairShareHelper.sol
@@ -1,0 +1,49 @@
+pragma solidity ^0.7.0;
+
+// SPDX-License-Identifier: MIT
+
+/**
+MIT License
+
+Copyright (c) 2020 Openlaw
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+library FairShareHelper {
+    
+    /**
+     * @notice calculates the fair share amount based the total shares and current balance.
+     */
+    function calc(
+        uint256 balance,
+        uint256 shares,
+        uint256 _totalShares
+    ) internal pure returns (uint256) {
+        require(_totalShares != 0, "total shares should not be 0");
+        if (balance == 0) {
+            return 0;
+        }
+        uint256 prod = balance * shares;
+        if (prod / balance == shares) {
+            // no overflow in multiplication above?
+            return prod / _totalShares;
+        }
+        return (balance / _totalShares) * shares;
+    }
+}

--- a/contracts/helpers/FairShareHelper.sol
+++ b/contracts/helpers/FairShareHelper.sol
@@ -26,7 +26,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
 library FairShareHelper {
-    
     /**
      * @notice calculates the fair share amount based the total shares and current balance.
      */

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "scripts": {
     "test": "truffle test",
     "coverage": "truffle run coverage --network coverage",
-    "lint:fix": "prettier --write contracts/**/*",
-    "lint": "prettier --list-different contracts/**/*",
+    "lint:fix": "prettier --write contracts/**/* test/**/*.test.js",
+    "lint": "prettier --list-different contracts/**/*.sol test/**/*.test.js",
     "create": "graph create openlawteam/laoland-graph --node https://api.thegraph.com/deploy/",
     "create-local": "graph create openlawteam/laoland-graph --node http://127.0.0.1:8020",
     "codegen": "graph codegen",

--- a/test/adapters/guildkick.test.js
+++ b/test/adapters/guildkick.test.js
@@ -193,7 +193,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     });
     assert.equal(activeMember.toString(), "true");
 
-    await guildkickContract.kick(dao.address, kickProposalId, {
+    await guildkickContract.guildKick(dao.address, kickProposalId, {
       from: member,
       gasPrice: toBN("0"),
     });
@@ -274,7 +274,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     await advanceTime(10000);
 
     // The member gets kicked out of the DAO
-    await guildkickContract.kick(dao.address, kickProposalId, {
+    await guildkickContract.guildKick(dao.address, kickProposalId, {
       from: member,
       gasPrice: toBN("0"),
     });
@@ -282,7 +282,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     try {
       // The kicked member which is now inactive attemps to submit a kick proposal
       // to kick the member that started the previous guild kick
-      await guildkickContract.kick(dao.address, kickProposalId, {
+      await guildkickContract.guildKick(dao.address, kickProposalId, {
         from: memberToKick,
         gasPrice: toBN("0"),
       });
@@ -337,7 +337,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     try {
       // A non-member of the DAO attemps to process a kick proposal
-      await guildkickContract.kick(dao.address, kickProposalId, {
+      await guildkickContract.guildKick(dao.address, kickProposalId, {
         from: nonMember,
         gasPrice: toBN("0"),
       });
@@ -389,7 +389,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     await advanceTime(10000);
 
     // The member gets kicked out of the DAO
-    await guildkickContract.kick(dao.address, kickProposalId, {
+    await guildkickContract.guildKick(dao.address, kickProposalId, {
       from: member,
       gasPrice: toBN("0"),
     });
@@ -397,7 +397,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     try {
       // The kicked member which is now inactive attemps to submit a kick proposal
       // to kick the member that started the previous guild kick
-      await guildkickContract.kick(dao.address, kickProposalId, {
+      await guildkickContract.guildKick(dao.address, kickProposalId, {
         from: memberToKick,
         gasPrice: toBN("0"),
       });
@@ -449,14 +449,14 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     await advanceTime(10000);
 
     // The member gets kicked out of the DAO
-    await guildkickContract.kick(dao.address, kickProposalId, {
+    await guildkickContract.guildKick(dao.address, kickProposalId, {
       from: member,
       gasPrice: toBN("0"),
     });
 
     try {
       // The member attempts to process the same proposal again
-      await guildkickContract.kick(dao.address, kickProposalId, {
+      await guildkickContract.guildKick(dao.address, kickProposalId, {
         from: member,
         gasPrice: toBN("0"),
       });
@@ -510,7 +510,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     try {
       // The member attempts to process the same proposal again
       let invalidKickProposalId = 89;
-      await guildkickContract.kick(dao.address, invalidKickProposalId, {
+      await guildkickContract.guildKick(dao.address, invalidKickProposalId, {
         from: member,
         gasPrice: toBN("0"),
       });
@@ -562,7 +562,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     await advanceTime(10000);
 
     // The member gets kicked out and become inactive
-    await guildkickContract.kick(dao.address, kickProposalId, {
+    await guildkickContract.guildKick(dao.address, kickProposalId, {
       from: member,
       gasPrice: toBN("0"),
     });
@@ -577,7 +577,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     );
     kickProposalId = res.kickProposalId;
     try {
-      await guildkickContract.kick(dao.address, kickProposalId, {
+      await guildkickContract.guildKick(dao.address, kickProposalId, {
         from: member,
         gasPrice: toBN("0"),
       });
@@ -630,7 +630,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     try {
       // The member attemps to process the kick proposal that did not pass
-      await guildkickContract.kick(dao.address, kickProposalId, {
+      await guildkickContract.guildKick(dao.address, kickProposalId, {
         from: member,
         gasPrice: toBN("0"),
       });
@@ -684,7 +684,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     try {
       // The member attemps to process the kick proposal, but the Advisor does not have any SHARES, only LOOT
-      await guildkickContract.kick(dao.address, kickProposalId, {
+      await guildkickContract.guildKick(dao.address, kickProposalId, {
         from: member,
         gasPrice: toBN("0"),
       });
@@ -734,7 +734,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     });
     await advanceTime(10000);
 
-    await guildkickContract.kick(dao.address, kickProposalId, {
+    await guildkickContract.guildKick(dao.address, kickProposalId, {
       from: member,
       gasPrice: toBN("0"),
     });
@@ -814,7 +814,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     await advanceTime(10000);
 
     // Process guild kick proposal
-    await guildkickContract.kick(dao.address, kickProposalId, {
+    await guildkickContract.guildKick(dao.address, kickProposalId, {
       from: member,
       gasPrice: toBN("0"),
     });
@@ -895,7 +895,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     });
     await advanceTime(10000);
 
-    await guildkickContract.kick(dao.address, kickProposalId, {
+    await guildkickContract.guildKick(dao.address, kickProposalId, {
       from: member,
       gasPrice: toBN("0"),
     });
@@ -975,7 +975,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     });
     await advanceTime(10000);
 
-    await guildkickContract.kick(dao.address, kickProposalId, {
+    await guildkickContract.guildKick(dao.address, kickProposalId, {
       from: member,
       gasPrice: toBN("0"),
     });
@@ -1048,7 +1048,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     });
     await advanceTime(10000);
 
-    await guildkickContract.kick(dao.address, kickProposalId, {
+    await guildkickContract.guildKick(dao.address, kickProposalId, {
       from: member,
       gasPrice: toBN("0"),
     });

--- a/test/adapters/guildkick.test.js
+++ b/test/adapters/guildkick.test.js
@@ -66,7 +66,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     );
     //Get the new proposal id
     let pastEvents = await dao.getPastEvents();
-    let { proposalId } = pastEvents[0].returnValues;
+    let {proposalId} = pastEvents[0].returnValues;
     return proposalId;
   };
 
@@ -132,9 +132,9 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     //Get the new proposal id
     let pastEvents = await dao.getPastEvents();
-    let { proposalId } = pastEvents[0].returnValues;
+    let {proposalId} = pastEvents[0].returnValues;
 
-    return { kickProposalId: proposalId };
+    return {kickProposalId: proposalId};
   };
 
   it("should be possible to kick a DAO member", async () => {
@@ -171,7 +171,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     //SubGuildKick
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKickProposal(
+    let {kickProposalId} = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -259,7 +259,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Start a new kick poposal
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKickProposal(
+    let {kickProposalId} = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -319,7 +319,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Start a new kick poposal
     let memberToKick = newMemberA;
-    let { kickProposalId } = await guildKickProposal(
+    let {kickProposalId} = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -374,7 +374,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Start a new kick poposal
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKickProposal(
+    let {kickProposalId} = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -434,7 +434,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Start a new kick poposal
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKickProposal(
+    let {kickProposalId} = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -493,7 +493,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Start a new kick poposal
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKickProposal(
+    let {kickProposalId} = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -547,7 +547,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Start a new kick poposal
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKickProposal(
+    let {kickProposalId} = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -614,7 +614,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Start a new kick poposal
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKickProposal(
+    let {kickProposalId} = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -668,7 +668,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Start a new kick poposal to kick out the advisor
     let memberToKick = advisor;
-    let { kickProposalId } = await guildKickProposal(
+    let {kickProposalId} = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -720,7 +720,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     //SubGuildKick
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKickProposal(
+    let {kickProposalId} = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -799,7 +799,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Submit guild kick proposal
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKickProposal(
+    let {kickProposalId} = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -881,7 +881,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     //SubGuildKick
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKickProposal(
+    let {kickProposalId} = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -916,11 +916,11 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
       ETH_TOKEN,
       requestedAmount,
       fromUtf8(""),
-      { gasPrice: toBN("0") }
+      {gasPrice: toBN("0")}
     );
 
     let pastEvents = await dao.getPastEvents();
-    let { proposalId } = pastEvents[0].returnValues;
+    let {proposalId} = pastEvents[0].returnValues;
 
     try {
       // kicked member attemps to sponsor the financing proposal to get grant
@@ -961,7 +961,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     //SubGuildKick
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKickProposal(
+    let {kickProposalId} = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -999,7 +999,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
         newModuleId,
         newModuleAddress,
         0,
-        { from: kickedMember, gasPrice: toBN("0") }
+        {from: kickedMember, gasPrice: toBN("0")}
       );
       assert.fail(
         "should not be possible for a kicked member to submit a managing proposal"
@@ -1034,7 +1034,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     //SubGuildKick
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKickProposal(
+    let {kickProposalId} = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -1069,12 +1069,12 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
       newModuleId,
       newModuleAddress,
       0,
-      { from: member, gasPrice: toBN("0") }
+      {from: member, gasPrice: toBN("0")}
     );
 
     //Get the new proposal id
     let pastEvents = await dao.getPastEvents();
-    let { proposalId } = pastEvents[0].returnValues;
+    let {proposalId} = pastEvents[0].returnValues;
 
     try {
       // kicked member attemps to sponsor a managing proposal
@@ -1114,7 +1114,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Submit GuildKick
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKickProposal(
+    let {kickProposalId} = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -1238,7 +1238,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Submit GuildKick
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKickProposal(
+    let {kickProposalId} = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -1284,7 +1284,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Submit GuildKick
     let memberToKick = newMember;
-    let { kickProposalId } = await guildKickProposal(
+    let {kickProposalId} = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,

--- a/test/adapters/guildkick.test.js
+++ b/test/adapters/guildkick.test.js
@@ -66,7 +66,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
     );
     //Get the new proposal id
     let pastEvents = await dao.getPastEvents();
-    let {proposalId} = pastEvents[0].returnValues;
+    let { proposalId } = pastEvents[0].returnValues;
     return proposalId;
   };
 
@@ -132,9 +132,9 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     //Get the new proposal id
     let pastEvents = await dao.getPastEvents();
-    let {proposalId} = pastEvents[0].returnValues;
+    let { proposalId } = pastEvents[0].returnValues;
 
-    return {kickProposalId: proposalId};
+    return { kickProposalId: proposalId };
   };
 
   it("should be possible to kick a DAO member", async () => {
@@ -171,7 +171,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     //SubGuildKick
     let memberToKick = newMember;
-    let {kickProposalId} = await guildKickProposal(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -259,7 +259,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Start a new kick poposal
     let memberToKick = newMember;
-    let {kickProposalId} = await guildKickProposal(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -319,7 +319,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Start a new kick poposal
     let memberToKick = newMemberA;
-    let {kickProposalId} = await guildKickProposal(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -374,7 +374,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Start a new kick poposal
     let memberToKick = newMember;
-    let {kickProposalId} = await guildKickProposal(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -434,7 +434,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Start a new kick poposal
     let memberToKick = newMember;
-    let {kickProposalId} = await guildKickProposal(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -493,7 +493,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Start a new kick poposal
     let memberToKick = newMember;
-    let {kickProposalId} = await guildKickProposal(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -547,7 +547,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Start a new kick poposal
     let memberToKick = newMember;
-    let {kickProposalId} = await guildKickProposal(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -614,7 +614,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Start a new kick poposal
     let memberToKick = newMember;
-    let {kickProposalId} = await guildKickProposal(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -668,7 +668,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Start a new kick poposal to kick out the advisor
     let memberToKick = advisor;
-    let {kickProposalId} = await guildKickProposal(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -720,7 +720,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     //SubGuildKick
     let memberToKick = newMember;
-    let {kickProposalId} = await guildKickProposal(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -799,7 +799,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Submit guild kick proposal
     let memberToKick = newMember;
-    let {kickProposalId} = await guildKickProposal(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -881,7 +881,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     //SubGuildKick
     let memberToKick = newMember;
-    let {kickProposalId} = await guildKickProposal(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -916,11 +916,11 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
       ETH_TOKEN,
       requestedAmount,
       fromUtf8(""),
-      {gasPrice: toBN("0")}
+      { gasPrice: toBN("0") }
     );
 
     let pastEvents = await dao.getPastEvents();
-    let {proposalId} = pastEvents[0].returnValues;
+    let { proposalId } = pastEvents[0].returnValues;
 
     try {
       // kicked member attemps to sponsor the financing proposal to get grant
@@ -961,7 +961,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     //SubGuildKick
     let memberToKick = newMember;
-    let {kickProposalId} = await guildKickProposal(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -999,7 +999,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
         newModuleId,
         newModuleAddress,
         0,
-        {from: kickedMember, gasPrice: toBN("0")}
+        { from: kickedMember, gasPrice: toBN("0") }
       );
       assert.fail(
         "should not be possible for a kicked member to submit a managing proposal"
@@ -1034,7 +1034,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     //SubGuildKick
     let memberToKick = newMember;
-    let {kickProposalId} = await guildKickProposal(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -1069,12 +1069,12 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
       newModuleId,
       newModuleAddress,
       0,
-      {from: member, gasPrice: toBN("0")}
+      { from: member, gasPrice: toBN("0") }
     );
 
     //Get the new proposal id
     let pastEvents = await dao.getPastEvents();
-    let {proposalId} = pastEvents[0].returnValues;
+    let { proposalId } = pastEvents[0].returnValues;
 
     try {
       // kicked member attemps to sponsor a managing proposal
@@ -1114,7 +1114,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Submit GuildKick
     let memberToKick = newMember;
-    let {kickProposalId} = await guildKickProposal(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -1238,7 +1238,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Submit GuildKick
     let memberToKick = newMember;
-    let {kickProposalId} = await guildKickProposal(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,
@@ -1284,7 +1284,7 @@ contract("LAOLAND - GuildKick Adapter", async (accounts) => {
 
     // Submit GuildKick
     let memberToKick = newMember;
-    let {kickProposalId} = await guildKickProposal(
+    let { kickProposalId } = await guildKickProposal(
       dao,
       guildkickContract,
       memberToKick,

--- a/test/adapters/managing.test.js
+++ b/test/adapters/managing.test.js
@@ -1,5 +1,5 @@
 // Whole-script strict mode syntax
-'use strict';
+"use strict";
 
 /**
 MIT License
@@ -24,10 +24,20 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
-const {sha3, toBN, advanceTime, createDao, GUILD, TOTAL, ETH_TOKEN, ManagingContract, VotingContract, OnboardingContract} = require('../../utils/DaoFactory.js');
+const {
+  sha3,
+  toBN,
+  advanceTime,
+  createDao,
+  GUILD,
+  TOTAL,
+  ETH_TOKEN,
+  ManagingContract,
+  VotingContract,
+  OnboardingContract,
+} = require("../../utils/DaoFactory.js");
 
-contract('LAOLAND - Managing Adapter', async accounts => {
-  
+contract("LAOLAND - Managing Adapter", async (accounts) => {
   it("should not be possible to propose a new module with 0x0 module address", async () => {
     const myAccount = accounts[1];
 
@@ -35,42 +45,59 @@ contract('LAOLAND - Managing Adapter', async accounts => {
     let dao = await createDao(myAccount);
 
     //Submit a new Bank module proposal
-    let newModuleId = sha3('bank');
-    let managingContract = await dao.getAdapterAddress(sha3('managing'));
+    let newModuleId = sha3("bank");
+    let managingContract = await dao.getAdapterAddress(sha3("managing"));
     let managing = await ManagingContract.at(managingContract);
     try {
-      await managing.createModuleChangeRequest(dao.address, newModuleId, ETH_TOKEN, 0, { from: myAccount, gasPrice: toBN("0") });
+      await managing.createModuleChangeRequest(
+        dao.address,
+        newModuleId,
+        ETH_TOKEN,
+        0,
+        {from: myAccount, gasPrice: toBN("0")}
+      );
       assert.err("should not pass");
     } catch (err) {
       assert.equal(err.reason, "invalid module address");
     }
-
-  })
+  });
 
   it("should not be possible to propose a new module when the module has a reserved address", async () => {
     const myAccount = accounts[1];
-    
+
     //Create the new DAO
     let dao = await createDao(myAccount);
 
     //Submit a new Bank module proposal
-    let newModuleId = sha3('bank');
-    let managingContract = await dao.getAdapterAddress(sha3('managing'));
+    let newModuleId = sha3("bank");
+    let managingContract = await dao.getAdapterAddress(sha3("managing"));
     let managing = await ManagingContract.at(managingContract);
     try {
-      await managing.createModuleChangeRequest(dao.address, newModuleId, GUILD, 0, { from: myAccount, gasPrice: toBN("0") });
+      await managing.createModuleChangeRequest(
+        dao.address,
+        newModuleId,
+        GUILD,
+        0,
+        {from: myAccount, gasPrice: toBN("0")}
+      );
       assert.err("should not pass");
     } catch (err) {
       assert.equal(err.reason, "module is using reserved address");
     }
-    
+
     try {
-      await managing.createModuleChangeRequest(dao.address, newModuleId, TOTAL, 0, { from: myAccount, gasPrice: toBN("0") });
+      await managing.createModuleChangeRequest(
+        dao.address,
+        newModuleId,
+        TOTAL,
+        0,
+        {from: myAccount, gasPrice: toBN("0")}
+      );
       assert.err("should not pass");
     } catch (err) {
       assert.equal(err.reason, "module is using reserved address");
     }
-  })
+  });
 
   it("should not be possible to propose a new module with an empty module address", async () => {
     const myAccount = accounts[1];
@@ -79,46 +106,64 @@ contract('LAOLAND - Managing Adapter', async accounts => {
     let dao = await createDao(myAccount);
 
     //Submit a new Bank module proposal
-    let newModuleId = sha3('managing');
-    let managingContract = await dao.getAdapterAddress(sha3('managing'));
+    let newModuleId = sha3("managing");
+    let managingContract = await dao.getAdapterAddress(sha3("managing"));
     let managing = await ManagingContract.at(managingContract);
     try {
-      await managing.createModuleChangeRequest(dao.address, newModuleId, "", { from: myAccount, gasPrice: toBN("0") });
+      await managing.createModuleChangeRequest(dao.address, newModuleId, "", {
+        from: myAccount,
+        gasPrice: toBN("0"),
+      });
       assert.err("should not pass");
     } catch (err) {
       assert.equal(err.reason, "invalid address");
     }
-  })
+  });
 
   it("should be possible to any individual to propose a new DAO module", async () => {
     const myAccount = accounts[1];
 
     //Create the new DAO
     let dao = await createDao(myAccount);
-    let managingContract = await dao.getAdapterAddress(sha3('managing'));
+    let managingContract = await dao.getAdapterAddress(sha3("managing"));
     let managing = await ManagingContract.at(managingContract);
 
-    let votingContract = await dao.getAdapterAddress(sha3('voting'));
+    let votingContract = await dao.getAdapterAddress(sha3("voting"));
     let voting = await VotingContract.at(votingContract);
 
     //Submit a new Bank module proposal
-    let newModuleId = sha3('onboarding');
+    let newModuleId = sha3("onboarding");
     let newModuleAddress = accounts[3]; //TODO deploy some Banking test contract
-    await managing.createModuleChangeRequest(dao.address, newModuleId, newModuleAddress, 0, { from: myAccount, gasPrice: toBN("0") });
+    await managing.createModuleChangeRequest(
+      dao.address,
+      newModuleId,
+      newModuleAddress,
+      0,
+      {from: myAccount, gasPrice: toBN("0")}
+    );
 
     //Get the new proposal id
     let proposalId = 0;
-    
-    //Sponsor the new proposal, vote and process it 
-    await managing.sponsorProposal(dao.address, proposalId, [], { from: myAccount, gasPrice: toBN("0") });
-    await voting.submitVote(dao.address, proposalId, 1, { from: myAccount, gasPrice: toBN("0") });
+
+    //Sponsor the new proposal, vote and process it
+    await managing.sponsorProposal(dao.address, proposalId, [], {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
+    await voting.submitVote(dao.address, proposalId, 1, {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
     await advanceTime(10000);
-    await managing.processProposal(dao.address, proposalId, { from: myAccount, gasPrice: toBN("0") });
+    await managing.processProposal(dao.address, proposalId, {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
 
     //Check if the Bank Module was added to the Registry
-    let newBankAddress = await dao.getAdapterAddress(sha3('onboarding'));
+    let newBankAddress = await dao.getAdapterAddress(sha3("onboarding"));
     assert.equal(newBankAddress.toString(), newModuleAddress.toString());
-  })
+  });
 
   it("should be possible to propose a new DAO module with a delegate key", async () => {
     const myAccount = accounts[1];
@@ -126,37 +171,58 @@ contract('LAOLAND - Managing Adapter', async accounts => {
 
     //Create the new DAO
     let dao = await createDao(myAccount);
-    let managingContract = await dao.getAdapterAddress(sha3('managing'));
+    let managingContract = await dao.getAdapterAddress(sha3("managing"));
     let managing = await ManagingContract.at(managingContract);
 
-    let votingContract = await dao.getAdapterAddress(sha3('voting'));
+    let votingContract = await dao.getAdapterAddress(sha3("voting"));
     let voting = await VotingContract.at(votingContract);
     //Submit a new Bank module proposal
-    let newModuleId = sha3('onboarding');
+    let newModuleId = sha3("onboarding");
     let newModuleAddress = accounts[4]; //TODO deploy some Banking test contract
-    await managing.createModuleChangeRequest(dao.address, newModuleId, newModuleAddress, 0, { from: myAccount, gasPrice: toBN("0") });
-    
-    let proposalId = 0;
-    
-    //set new delegate key
-    const onboardingAddr = await dao.getAdapterAddress(sha3('onboarding'));
-    const onboarding = await OnboardingContract.at(onboardingAddr);
-    await onboarding.updateDelegateKey(dao.address, delegateKey, { from: myAccount, gasPrice: toBN("0") });
+    await managing.createModuleChangeRequest(
+      dao.address,
+      newModuleId,
+      newModuleAddress,
+      0,
+      {from: myAccount, gasPrice: toBN("0")}
+    );
 
-    //Sponsor the new proposal, vote and process it 
-    await managing.sponsorProposal(dao.address, proposalId, [], { from: delegateKey, gasPrice: toBN("0") });
-    await voting.submitVote(dao.address, proposalId, 1, { from: delegateKey, gasPrice: toBN("0") });
+    let proposalId = 0;
+
+    //set new delegate key
+    const onboardingAddr = await dao.getAdapterAddress(sha3("onboarding"));
+    const onboarding = await OnboardingContract.at(onboardingAddr);
+    await onboarding.updateDelegateKey(dao.address, delegateKey, {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
+
+    //Sponsor the new proposal, vote and process it
+    await managing.sponsorProposal(dao.address, proposalId, [], {
+      from: delegateKey,
+      gasPrice: toBN("0"),
+    });
+    await voting.submitVote(dao.address, proposalId, 1, {
+      from: delegateKey,
+      gasPrice: toBN("0"),
+    });
     try {
-      await voting.submitVote(dao.address, proposalId, 1, { from: myAccount, gasPrice: toBN("0") });
+      await voting.submitVote(dao.address, proposalId, 1, {
+        from: myAccount,
+        gasPrice: toBN("0"),
+      });
       assert.err("should not pass");
     } catch (err) {
       assert.equal(err.reason, "onlyMember");
     }
     await advanceTime(10000);
-    await managing.processProposal(dao.address, proposalId, { from: delegateKey, gasPrice: toBN("0") });
+    await managing.processProposal(dao.address, proposalId, {
+      from: delegateKey,
+      gasPrice: toBN("0"),
+    });
 
     //Check if the Bank Module was added to the Registry
-    let newBankAddress = await dao.getAdapterAddress(sha3('onboarding'));
+    let newBankAddress = await dao.getAdapterAddress(sha3("onboarding"));
     assert.equal(newBankAddress.toString(), newModuleAddress.toString());
-  })
+  });
 });

--- a/test/adapters/non-voting.membership.test.js
+++ b/test/adapters/non-voting.membership.test.js
@@ -1,5 +1,5 @@
 // Whole-script strict mode syntax
-'use strict';
+"use strict";
 
 /**
 MIT License
@@ -38,17 +38,14 @@ const {
   VotingContract,
 } = require("../../utils/DaoFactory.js");
 
-contract('LAOLAND - Non Voting Onboarding Adapter', async accounts => {
-
+contract("LAOLAND - Non Voting Onboarding Adapter", async (accounts) => {
   it("should be possible to join a DAO as a member without any voting power by requesting Loot while staking raw ETH", async () => {
     const myAccount = accounts[1];
     const advisorAccount = accounts[2];
 
     let dao = await createDao(myAccount);
 
-    const onboardingAddress = await dao.getAdapterAddress(
-      sha3("onboarding")
-    );
+    const onboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
     const onboarding = await OnboardingContract.at(onboardingAddress);
 
     const votingAddress = await dao.getAdapterAddress(sha3("voting"));
@@ -77,7 +74,7 @@ contract('LAOLAND - Non Voting Onboarding Adapter', async accounts => {
     await voting.submitVote(dao.address, proposalId, 1, {
       from: myAccount,
       gasPrice: toBN("0"),
-    })
+    });
 
     // Process the new proposal
     await advanceTime(10000);
@@ -96,7 +93,7 @@ contract('LAOLAND - Non Voting Onboarding Adapter', async accounts => {
       "0x0000000000000000000000000000000000000000"
     );
     assert.equal(guildBalance.toString(), "360000000000000000");
-  })
+  });
 
   it("should be possible to join a DAO as a member without any voting power by requesting Loot while staking ERC20 token", async () => {
     const myAccount = accounts[1];
@@ -108,20 +105,23 @@ contract('LAOLAND - Non Voting Onboarding Adapter', async accounts => {
 
     let lootSharePrice = 10;
     let nbOfLootShares = 100000000;
-    
-    let dao = await createDao(myAccount, lootSharePrice, nbOfLootShares, 10, 1, oltContract.address);
 
-    const onboardingAddress = await dao.getAdapterAddress(
-      sha3("onboarding")
+    let dao = await createDao(
+      myAccount,
+      lootSharePrice,
+      nbOfLootShares,
+      10,
+      1,
+      oltContract.address
     );
+
+    const onboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
     const onboarding = await OnboardingContract.at(onboardingAddress);
 
     // Transfer 1000 OLTs to the Advisor account
     await oltContract.approve(advisorAccount, 100);
     await oltContract.transfer(advisorAccount, 100);
-    let advisorTokenBalance = await oltContract.balanceOf.call(
-      advisorAccount
-    );
+    let advisorTokenBalance = await oltContract.balanceOf.call(advisorAccount);
     assert.equal(
       "100",
       advisorTokenBalance.toString(),
@@ -137,36 +137,26 @@ contract('LAOLAND - Non Voting Onboarding Adapter', async accounts => {
     // Pre-approve spender (DAO) to transfer applicant tokens
     await oltContract.approve(dao.address, tokenAmount, {from: advisorAccount});
 
-    // Send a request to join the DAO as an Advisor (non-voting power), 
+    // Send a request to join the DAO as an Advisor (non-voting power),
     // the tx passes the OLT ERC20 token, the amount and the nonVotingOnboarding adapter that handles the proposal
     try {
-      await onboarding.onboard(
-        dao.address,
-				advisorAccount,
-        LOOT,
-        tokenAmount,
-        {
-          from: advisorAccount,
-          gasPrice: toBN("0"),
-        }
-      );
+      await onboarding.onboard(dao.address, advisorAccount, LOOT, tokenAmount, {
+        from: advisorAccount,
+        gasPrice: toBN("0"),
+      });
       assert.equal(true, false, "should have failed!");
     } catch (err) {
       assert.equal(err.message.indexOf("ERC20 transfer not allowed") > 0, true);
     }
 
-    await oltContract.approve(onboarding.address, tokenAmount, {from: advisorAccount});
+    await oltContract.approve(onboarding.address, tokenAmount, {
+      from: advisorAccount,
+    });
 
-    await onboarding.onboard(
-      dao.address,
-			advisorAccount,
-      LOOT,
-      tokenAmount,
-      {
-        from: advisorAccount,
-        gasPrice: toBN("0"),
-      }
-    );
+    await onboarding.onboard(dao.address, advisorAccount, LOOT, tokenAmount, {
+      from: advisorAccount,
+      gasPrice: toBN("0"),
+    });
 
     // Sponsor the new proposal to allow the Advisor to join the DAO
     await onboarding.sponsorProposal(dao.address, 0, [], {

--- a/test/adapters/offchain.voting.test.js
+++ b/test/adapters/offchain.voting.test.js
@@ -1,5 +1,5 @@
 // Whole-script strict mode syntax
-'use strict';
+"use strict";
 
 /**
 MIT License
@@ -24,49 +24,110 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
-const {sha3, toBN, advanceTime, SHARES, OnboardingContract, DaoRegistry, DaoFactory, FlagHelperLib, sharePrice, remaining, numberOfShares, entry, addDefaultAdapters} = require('../../utils/DaoFactory.js');
-const {addVote, prepareVoteResult, toStepNode} = require('../../utils/offchain_voting.js');
+const {
+  sha3,
+  toBN,
+  advanceTime,
+  SHARES,
+  OnboardingContract,
+  DaoRegistry,
+  DaoFactory,
+  FlagHelperLib,
+  sharePrice,
+  remaining,
+  numberOfShares,
+  entry,
+  addDefaultAdapters,
+} = require("../../utils/DaoFactory.js");
+const {
+  addVote,
+  prepareVoteResult,
+  toStepNode,
+} = require("../../utils/offchain_voting.js");
 
-const OffchainVotingContract = artifacts.require('./adapters/OffchainVotingContract');
+const OffchainVotingContract = artifacts.require(
+  "./adapters/OffchainVotingContract"
+);
 
-async function createOffchainVotingDao(senderAccount, unitPrice=sharePrice, nbShares=numberOfShares, votingPeriod=10, gracePeriod=1) {
+async function createOffchainVotingDao(
+  senderAccount,
+  unitPrice = sharePrice,
+  nbShares = numberOfShares,
+  votingPeriod = 10,
+  gracePeriod = 1
+) {
   let lib = await FlagHelperLib.new();
   const daoFactory = await DaoFactory.new();
   await DaoRegistry.link("FlagHelper", lib.address);
-  let dao = await DaoRegistry.new({ from: senderAccount, gasPrice: toBN("0") });
+  let dao = await DaoRegistry.new({from: senderAccount, gasPrice: toBN("0")});
   await addDefaultAdapters(dao, unitPrice, nbShares, votingPeriod, gracePeriod);
   const votingAddress = await dao.getAdapterAddress(sha3("voting"));
   const offchainVoting = await OffchainVotingContract.new(votingAddress);
   await daoFactory.updateAdapter(
     dao.address,
-    entry("voting", offchainVoting, {ADD_TO_BALANCE: true, SUB_FROM_BALANCE: true, INTERNAL_TRANSFER: true}))
+    entry("voting", offchainVoting, {
+      ADD_TO_BALANCE: true,
+      SUB_FROM_BALANCE: true,
+      INTERNAL_TRANSFER: true,
+    })
+  );
 
   await offchainVoting.configureDao(dao.address, votingPeriod, gracePeriod, 10);
   await dao.finalizeDao();
   return {dao, voting: offchainVoting};
 }
 
-contract('LAOLAND - Offchain Voting Module', async accounts => {
-
+contract("LAOLAND - Offchain Voting Module", async (accounts) => {
   it("should be possible to vote offchain", async () => {
     const myAccount = accounts[1];
     const otherAccount = accounts[2];
     let {dao, voting} = await createOffchainVotingDao(myAccount);
 
-    const onboardingAddress = await dao.getAdapterAddress(sha3('onboarding'));
+    const onboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
     const onboarding = await OnboardingContract.at(onboardingAddress);
 
-    await onboarding.onboard(dao.address, otherAccount, SHARES, sharePrice.mul(toBN(3)).add(remaining), {from:myAccount,value:sharePrice.mul(toBN("3")).add(remaining), gasPrice: toBN("0")});
+    await onboarding.onboard(
+      dao.address,
+      otherAccount,
+      SHARES,
+      sharePrice.mul(toBN(3)).add(remaining),
+      {
+        from: myAccount,
+        value: sharePrice.mul(toBN("3")).add(remaining),
+        gasPrice: toBN("0"),
+      }
+    );
     let blockNumber = await web3.eth.getBlockNumber();
-    await onboarding.sponsorProposal(dao.address, 0, web3.eth.abi.encodeParameter('uint256', blockNumber), {from: myAccount, gasPrice: toBN("0")});
-    
-    const voteElements = await addVote([], blockNumber, dao, 0, myAccount, true);
+    await onboarding.sponsorProposal(
+      dao.address,
+      0,
+      web3.eth.abi.encodeParameter("uint256", blockNumber),
+      {from: myAccount, gasPrice: toBN("0")}
+    );
+
+    const voteElements = await addVote(
+      [],
+      blockNumber,
+      dao,
+      0,
+      myAccount,
+      true
+    );
     const {voteResultTree, votes} = prepareVoteResult(voteElements);
     const result = toStepNode(votes[0], voteResultTree);
-    
-    await voting.submitVoteResult(dao.address, 0, voteResultTree.getHexRoot(), result, {from: myAccount, gasPrice: toBN("0")});
+
+    await voting.submitVoteResult(
+      dao.address,
+      0,
+      voteResultTree.getHexRoot(),
+      result,
+      {from: myAccount, gasPrice: toBN("0")}
+    );
     await advanceTime(10000);
-    await onboarding.processProposal(dao.address, 0, {from: myAccount, gasPrice: toBN("0")});
+    await onboarding.processProposal(dao.address, 0, {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
   });
 
   it("should be possible to invalidate the vote if the node is in the wrong order", async () => {
@@ -76,37 +137,114 @@ contract('LAOLAND - Offchain Voting Module', async accounts => {
 
     let {dao, voting} = await createOffchainVotingDao(myAccount);
 
-    const onboardingAddress = await dao.getAdapterAddress(sha3('onboarding'));
+    const onboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
     const onboarding = await OnboardingContract.at(onboardingAddress);
 
-    await onboarding.onboard(dao.address, otherAccount, SHARES, sharePrice.mul(toBN(3)).add(remaining), {from:myAccount,value:sharePrice.mul(toBN(3)).add(remaining), gasPrice: toBN("0")});
-    await onboarding.onboard(dao.address, otherAccount2, SHARES, sharePrice.mul(toBN(3)).add(remaining), {from:myAccount,value:sharePrice.mul(toBN(3)).add(remaining), gasPrice: toBN("0")});
+    await onboarding.onboard(
+      dao.address,
+      otherAccount,
+      SHARES,
+      sharePrice.mul(toBN(3)).add(remaining),
+      {
+        from: myAccount,
+        value: sharePrice.mul(toBN(3)).add(remaining),
+        gasPrice: toBN("0"),
+      }
+    );
+    await onboarding.onboard(
+      dao.address,
+      otherAccount2,
+      SHARES,
+      sharePrice.mul(toBN(3)).add(remaining),
+      {
+        from: myAccount,
+        value: sharePrice.mul(toBN(3)).add(remaining),
+        gasPrice: toBN("0"),
+      }
+    );
     let blockNumber = await web3.eth.getBlockNumber();
-    
-    await onboarding.sponsorProposal(dao.address, 0, web3.eth.abi.encodeParameter('uint256', blockNumber), {from: myAccount, gasPrice: toBN("0")});
-    await onboarding.sponsorProposal(dao.address, 1, web3.eth.abi.encodeParameter('uint256', blockNumber), {from: myAccount, gasPrice: toBN("0")});
 
-    const voteElements = await addVote([], blockNumber, dao, 0, myAccount, true);
-    const voteElements2 = await addVote([], blockNumber, dao, 1, myAccount, true);
+    await onboarding.sponsorProposal(
+      dao.address,
+      0,
+      web3.eth.abi.encodeParameter("uint256", blockNumber),
+      {from: myAccount, gasPrice: toBN("0")}
+    );
+    await onboarding.sponsorProposal(
+      dao.address,
+      1,
+      web3.eth.abi.encodeParameter("uint256", blockNumber),
+      {from: myAccount, gasPrice: toBN("0")}
+    );
+
+    const voteElements = await addVote(
+      [],
+      blockNumber,
+      dao,
+      0,
+      myAccount,
+      true
+    );
+    const voteElements2 = await addVote(
+      [],
+      blockNumber,
+      dao,
+      1,
+      myAccount,
+      true
+    );
     const r1 = prepareVoteResult(voteElements);
     const r2 = prepareVoteResult(voteElements2);
 
     const result1 = toStepNode(r1.votes[0], r1.voteResultTree);
     const result2 = toStepNode(r2.votes[0], r2.voteResultTree);
 
-    await voting.submitVoteResult(dao.address, 0, r1.voteResultTree.getHexRoot(), result1, {from: myAccount, gasPrice: toBN("0")});
-    await voting.submitVoteResult(dao.address, 1, r2.voteResultTree.getHexRoot(), result2, {from: myAccount, gasPrice: toBN("0")});
+    await voting.submitVoteResult(
+      dao.address,
+      0,
+      r1.voteResultTree.getHexRoot(),
+      result1,
+      {from: myAccount, gasPrice: toBN("0")}
+    );
+    await voting.submitVoteResult(
+      dao.address,
+      1,
+      r2.voteResultTree.getHexRoot(),
+      result2,
+      {from: myAccount, gasPrice: toBN("0")}
+    );
     await advanceTime(10000);
-    await onboarding.processProposal(dao.address, 0, {from: myAccount, gasPrice: toBN("0")});
-    await onboarding.processProposal(dao.address, 1, {from: myAccount, gasPrice: toBN("0")});
+    await onboarding.processProposal(dao.address, 0, {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
+    await onboarding.processProposal(dao.address, 1, {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
 
     const someone = accounts[4];
 
-    await onboarding.onboard(dao.address, someone, SHARES, sharePrice.mul(toBN(3)).add(remaining), {from:myAccount,value:sharePrice.mul(toBN(3)).add(remaining), gasPrice: toBN("0")});
+    await onboarding.onboard(
+      dao.address,
+      someone,
+      SHARES,
+      sharePrice.mul(toBN(3)).add(remaining),
+      {
+        from: myAccount,
+        value: sharePrice.mul(toBN(3)).add(remaining),
+        gasPrice: toBN("0"),
+      }
+    );
 
     const proposalId = 2;
     blockNumber = await web3.eth.getBlockNumber();
-    await onboarding.sponsorProposal(dao.address, proposalId, web3.eth.abi.encodeParameter('uint256', blockNumber), {from: myAccount, gasPrice: toBN("0")});
+    await onboarding.sponsorProposal(
+      dao.address,
+      proposalId,
+      web3.eth.abi.encodeParameter("uint256", blockNumber),
+      {from: myAccount, gasPrice: toBN("0")}
+    );
     let ve = await addVote([], blockNumber, dao, proposalId, myAccount, true);
     ve = await addVote(ve, blockNumber, dao, proposalId, otherAccount, true);
     ve = await addVote(ve, blockNumber, dao, proposalId, otherAccount2, false);
@@ -116,11 +254,22 @@ contract('LAOLAND - Offchain Voting Module', async accounts => {
     const votes2 = r3.votes;
     const result3 = toStepNode(votes2[2], voteResultTree2);
 
-    await voting.submitVoteResult(dao.address, proposalId, voteResultTree2.getHexRoot(), result3, {from: myAccount, gasPrice: toBN("0")});
+    await voting.submitVoteResult(
+      dao.address,
+      proposalId,
+      voteResultTree2.getHexRoot(),
+      result3,
+      {from: myAccount, gasPrice: toBN("0")}
+    );
 
     const nodePrevious = toStepNode(votes2[0], voteResultTree2);
     const nodeCurrent = toStepNode(votes2[1], voteResultTree2);
 
-    await voting.challengeWrongStep(dao.address, proposalId, nodePrevious, nodeCurrent);
+    await voting.challengeWrongStep(
+      dao.address,
+      proposalId,
+      nodePrevious,
+      nodeCurrent
+    );
   });
 });

--- a/test/adapters/onboarding.test.js
+++ b/test/adapters/onboarding.test.js
@@ -1,5 +1,5 @@
 // Whole-script strict mode syntax
-'use strict';
+"use strict";
 
 /**
 MIT License
@@ -24,133 +24,214 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
-const {toBN, advanceTime, createDao, getContract, GUILD, SHARES, sharePrice, remaining, numberOfShares, OnboardingContract, VotingContract, ETH_TOKEN} = require('../../utils/DaoFactory.js');
-const {checkBalance} = require('../../utils/TestUtils.js');
+const {
+  toBN,
+  advanceTime,
+  createDao,
+  getContract,
+  GUILD,
+  SHARES,
+  sharePrice,
+  remaining,
+  numberOfShares,
+  OnboardingContract,
+  VotingContract,
+  ETH_TOKEN,
+} = require("../../utils/DaoFactory.js");
+const {checkBalance} = require("../../utils/TestUtils.js");
 
-contract('LAOLAND - Onboarding Adapter', async accounts => {
-
+contract("LAOLAND - Onboarding Adapter", async (accounts) => {
   it("should be possible to join a DAO", async () => {
     const myAccount = accounts[1];
     const otherAccount = accounts[2];
     const nonMemberAccount = accounts[3];
-    
+
     let dao = await createDao(myAccount);
-    
-    const onboarding = await getContract(dao, 'onboarding', OnboardingContract);
-    const voting = await getContract(dao, 'voting', VotingContract);
 
-    await onboarding.onboard(dao.address, otherAccount, SHARES, 0, {from:myAccount,value:sharePrice.mul(toBN(3)).add(remaining), gasPrice: toBN("0")});
-    await onboarding.sponsorProposal(dao.address, 0, [], {from: myAccount, gasPrice: toBN("0")});
+    const onboarding = await getContract(dao, "onboarding", OnboardingContract);
+    const voting = await getContract(dao, "voting", VotingContract);
 
-    voting.submitVote(dao.address, 0, 1, {from: myAccount, gasPrice: toBN("0")});
-    
+    await onboarding.onboard(dao.address, otherAccount, SHARES, 0, {
+      from: myAccount,
+      value: sharePrice.mul(toBN(3)).add(remaining),
+      gasPrice: toBN("0"),
+    });
+    await onboarding.sponsorProposal(dao.address, 0, [], {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
+
+    voting.submitVote(dao.address, 0, 1, {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
+
     try {
-      await onboarding.processProposal(dao.address, 0, {from: myAccount, gasPrice: toBN("0")});
-    } catch(err) {
+      await onboarding.processProposal(dao.address, 0, {
+        from: myAccount,
+        gasPrice: toBN("0"),
+      });
+    } catch (err) {
       assert.equal(err.reason, "proposal has not been voted on yet");
     }
-    
+
     await advanceTime(10000);
-    await onboarding.processProposal(dao.address, 0, {from: myAccount, gasPrice: toBN("0")});
-    
+    await onboarding.processProposal(dao.address, 0, {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
+
     const myAccountShares = await dao.balanceOf(myAccount, SHARES);
     const otherAccountShares = await dao.balanceOf(otherAccount, SHARES);
-    const nonMemberAccountShares = await dao.balanceOf(nonMemberAccount, SHARES);
+    const nonMemberAccountShares = await dao.balanceOf(
+      nonMemberAccount,
+      SHARES
+    );
     assert.equal(myAccountShares.toString(), "1");
-    assert.equal(otherAccountShares.toString(), numberOfShares.mul(toBN("3")).toString());
+    assert.equal(
+      otherAccountShares.toString(),
+      numberOfShares.mul(toBN("3")).toString()
+    );
     assert.equal(nonMemberAccountShares.toString(), "0");
     await checkBalance(dao, GUILD, ETH_TOKEN, sharePrice.mul(toBN("3")));
-  })
+  });
 
   it("should be possible to cancel an onboarding proposal", async () => {
     const myAccount = accounts[1];
     const otherAccount = accounts[2];
     const dao = await createDao(myAccount);
-    
-    const onboarding = await getContract(dao, 'onboarding', OnboardingContract);
 
-    await onboarding.onboard(dao.address, otherAccount, SHARES, 0, {from:myAccount,value:sharePrice.mul(toBN(3)).add(remaining), gasPrice: toBN("0")});
+    const onboarding = await getContract(dao, "onboarding", OnboardingContract);
 
-		await onboarding.cancelProposal(dao.address, 0, {from: myAccount, gasPrice: toBN("0")});
+    await onboarding.onboard(dao.address, otherAccount, SHARES, 0, {
+      from: myAccount,
+      value: sharePrice.mul(toBN(3)).add(remaining),
+      gasPrice: toBN("0"),
+    });
+
+    await onboarding.cancelProposal(dao.address, 0, {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
     const isProcessed = await dao.getProposalFlag(toBN("0"), toBN("2")); // 2 is processed flag index
-		assert.equal(isProcessed, true);
+    assert.equal(isProcessed, true);
 
     try {
-      await onboarding.sponsorProposal(dao.address, 0, [], {from: myAccount, gasPrice: toBN("0")});
-    } catch(err) {
+      await onboarding.sponsorProposal(dao.address, 0, [], {
+        from: myAccount,
+        gasPrice: toBN("0"),
+      });
+    } catch (err) {
       assert.equal(err.reason, "proposal already processed");
     }
 
     try {
-      await onboarding.processProposal(dao.address, 0, {from: myAccount, gasPrice: toBN("0")});
-    } catch(err) {
+      await onboarding.processProposal(dao.address, 0, {
+        from: myAccount,
+        gasPrice: toBN("0"),
+      });
+    } catch (err) {
       assert.equal(err.reason, "proposal already processed");
     }
-    
+
     const myAccountShares = await dao.balanceOf(myAccount, SHARES);
     const otherAccountShares = await dao.balanceOf(otherAccount, SHARES);
     assert.equal(myAccountShares.toString(), "1");
-    assert.equal(otherAccountShares.toString(), numberOfShares.mul(toBN("0")).toString());
+    assert.equal(
+      otherAccountShares.toString(),
+      numberOfShares.mul(toBN("0")).toString()
+    );
 
-    const guildBalance = await dao.balanceOf(GUILD, "0x0000000000000000000000000000000000000000");
+    const guildBalance = await dao.balanceOf(
+      GUILD,
+      "0x0000000000000000000000000000000000000000"
+    );
     assert.equal(guildBalance.toString(), sharePrice.mul(toBN("0")).toString());
-  })
+  });
 
   it("should be possible to withdraw an onboarding proposal", async () => {
     const myAccount = accounts[1];
-    const otherAccount = accounts[2];  
+    const otherAccount = accounts[2];
     let dao = await createDao(myAccount);
-  
-    const onboarding = await getContract(dao, 'onboarding', OnboardingContract);
-    const voting = await getContract(dao, 'voting', VotingContract);
-    
-    await onboarding.onboard(dao.address, otherAccount, SHARES, 0, {from:myAccount,value:sharePrice.mul(toBN(3)).add(remaining), gasPrice: toBN("0")});
-    await onboarding.sponsorProposal(dao.address, 0, [], {from: myAccount, gasPrice: toBN("0")});
 
-    await voting.submitVote(dao.address, 0, 2, {from: myAccount, gasPrice: toBN("0")});
+    const onboarding = await getContract(dao, "onboarding", OnboardingContract);
+    const voting = await getContract(dao, "voting", VotingContract);
+
+    await onboarding.onboard(dao.address, otherAccount, SHARES, 0, {
+      from: myAccount,
+      value: sharePrice.mul(toBN(3)).add(remaining),
+      gasPrice: toBN("0"),
+    });
+    await onboarding.sponsorProposal(dao.address, 0, [], {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
+
+    await voting.submitVote(dao.address, 0, 2, {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
     await advanceTime(10000);
-		const vote = await voting.voteResult(dao.address, 0);
-		assert.equal(vote.toString(), "3"); // vote should be "not passed"
-    
-    await onboarding.processProposal(dao.address, 0, {from: myAccount, gasPrice: toBN("0")});
+    const vote = await voting.voteResult(dao.address, 0);
+    assert.equal(vote.toString(), "3"); // vote should be "not passed"
+
+    await onboarding.processProposal(dao.address, 0, {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
 
     const isProcessed = await dao.getProposalFlag(toBN("0"), toBN("2")); // 2 is processed flag index
-		assert.equal(isProcessed, true);
-    
+    assert.equal(isProcessed, true);
+
     const myAccountShares = await dao.balanceOf(myAccount, SHARES);
     const otherAccountShares = await dao.balanceOf(otherAccount, SHARES);
     assert.equal(myAccountShares.toString(), "1");
-    assert.equal(otherAccountShares.toString(), numberOfShares.mul(toBN("0")).toString());
+    assert.equal(
+      otherAccountShares.toString(),
+      numberOfShares.mul(toBN("0")).toString()
+    );
 
-    const guildBalance = await dao.balanceOf(GUILD, "0x0000000000000000000000000000000000000000");
+    const guildBalance = await dao.balanceOf(
+      GUILD,
+      "0x0000000000000000000000000000000000000000"
+    );
     assert.equal(guildBalance.toString(), sharePrice.mul(toBN("0")).toString());
-  })
+  });
 
   it("should validate inputs", async () => {
     const myAccount = accounts[1];
-    const otherAccount = accounts[2];  
+    const otherAccount = accounts[2];
     let dao = await createDao(myAccount);
-  
-    const onboarding = await getContract(dao, 'onboarding', OnboardingContract);
-    
+
+    const onboarding = await getContract(dao, "onboarding", OnboardingContract);
+
     try {
-      await onboarding.sponsorProposal(dao.address, 1, [], {from: myAccount, gasPrice: toBN("0")});
-    } catch(err) {
+      await onboarding.sponsorProposal(dao.address, 1, [], {
+        from: myAccount,
+        gasPrice: toBN("0"),
+      });
+    } catch (err) {
       assert.equal(err.reason, "proposal does not exist");
     }
 
-		const bigint = toBN("0x111111111111111111111111111111111111")
+    const bigint = toBN("0x111111111111111111111111111111111111");
 
     try {
-      await onboarding.processProposal(dao.address, bigint, {from: myAccount, gasPrice: toBN("0")});
-    } catch(err) {
+      await onboarding.processProposal(dao.address, bigint, {
+        from: myAccount,
+        gasPrice: toBN("0"),
+      });
+    } catch (err) {
       assert.equal(err.reason, "proposalId too big");
     }
 
     try {
-		  await onboarding.cancelProposal(dao.address, bigint, {from: myAccount, gasPrice: toBN("0")});
-    } catch(err) {
+      await onboarding.cancelProposal(dao.address, bigint, {
+        from: myAccount,
+        gasPrice: toBN("0"),
+      });
+    } catch (err) {
       assert.equal(err.reason, "proposalId too big");
     }
-  })
+  });
 });

--- a/test/adapters/ragequit.test.js
+++ b/test/adapters/ragequit.test.js
@@ -1,5 +1,5 @@
 // Whole-script strict mode syntax
-'use strict';
+"use strict";
 
 /**
 MIT License
@@ -35,27 +35,37 @@ const {
   ETH_TOKEN,
   SHARES,
   LOOT,
-  OLTokenContract, 
+  OLTokenContract,
   OnboardingContract,
   VotingContract,
   RagequitContract,
-  FinancingContract
+  FinancingContract,
 } = require("../../utils/DaoFactory.js");
-const { checkLastEvent } = require("../../utils/TestUtils.js");
+const {checkLastEvent} = require("../../utils/TestUtils.js");
 
-contract('LAOLAND - Ragequit Adapter', async accounts => {
-
-  const submitNewMemberProposal = async (onboarding, dao, newMember, sharePrice) => {
+contract("LAOLAND - Ragequit Adapter", async (accounts) => {
+  const submitNewMemberProposal = async (
+    onboarding,
+    dao,
+    newMember,
+    sharePrice
+  ) => {
     const myAccount = accounts[1];
-		
-    await onboarding.onboard(dao.address, newMember, SHARES, sharePrice.mul(toBN(100)), {
-      from: myAccount,
-      value: sharePrice.mul(toBN(100)),
-      gasPrice: toBN("0"),
-    });
+
+    await onboarding.onboard(
+      dao.address,
+      newMember,
+      SHARES,
+      sharePrice.mul(toBN(100)),
+      {
+        from: myAccount,
+        value: sharePrice.mul(toBN(100)),
+        gasPrice: toBN("0"),
+      }
+    );
     //Get the new proposal id
     let pastEvents = await dao.getPastEvents();
-    let { proposalId } = pastEvents[0].returnValues;
+    let {proposalId} = pastEvents[0].returnValues;
     return proposalId;
   };
 
@@ -75,15 +85,20 @@ contract('LAOLAND - Ragequit Adapter', async accounts => {
       gasPrice: toBN("0"),
     });
     await advanceTime(10000);
-  }
+  };
 
   const ragequit = async (dao, shares, loot, member) => {
     let ragequitAddress = await dao.getAdapterAddress(sha3("ragequit"));
     let ragequitContract = await RagequitContract.at(ragequitAddress);
-    await ragequitContract.startRagequit(dao.address, toBN(shares), toBN(loot), {
-      from: member,
-      gasPrice: toBN("0"),
-    });
+    await ragequitContract.startRagequit(
+      dao.address,
+      toBN(shares),
+      toBN(loot),
+      {
+        from: member,
+        gasPrice: toBN("0"),
+      }
+    );
 
     await ragequitContract.burnShares(dao.address, member, 2, {
       gasPrice: toBN("0"),
@@ -93,27 +108,35 @@ contract('LAOLAND - Ragequit Adapter', async accounts => {
     let newShares = await dao.balanceOf(member, SHARES);
     assert.equal(newShares.toString(), "0");
     return ragequitContract;
-  }
+  };
 
   it("should not be possible for a non DAO member to ragequit", async () => {
     const myAccount = accounts[1];
     const newMember = accounts[2];
-  
+
     let dao = await createDao(myAccount);
 
     //Add funds to the Guild Bank after sposoring a member to join the Guild
-    const onboardingAddress = await dao.getAdapterAddress(sha3('onboarding'));
+    const onboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
     const onboarding = await OnboardingContract.at(onboardingAddress);
 
     const votingAddress = await dao.getAdapterAddress(sha3("voting"));
     const voting = await VotingContract.at(votingAddress);
 
-    let proposalId = await submitNewMemberProposal(onboarding, dao, newMember, sharePrice);
+    let proposalId = await submitNewMemberProposal(
+      onboarding,
+      dao,
+      newMember,
+      sharePrice
+    );
 
-    //Sponsor the new proposal, vote and process it 
+    //Sponsor the new proposal, vote and process it
     await sponsorNewMember(onboarding, dao, proposalId, myAccount, voting);
-    await onboarding.processProposal(dao.address, proposalId, { from: myAccount, gasPrice: toBN("0") });
-  
+    await onboarding.processProposal(dao.address, proposalId, {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
+
     //Check Guild Bank Balance
     let guildBalance = await dao.balanceOf(GUILD, ETH_TOKEN);
     assert.equal(toBN(guildBalance).toString(), "12000000000000000000");
@@ -126,10 +149,10 @@ contract('LAOLAND - Ragequit Adapter', async accounts => {
     try {
       let nonMember = accounts[4];
       await ragequit(dao, shares, 0, nonMember);
-    } catch (error){
+    } catch (error) {
       assert.equal(error.reason, "onlyMember");
     }
-  })
+  });
 
   it("should not be possible to a member to ragequit when the member does not have enough shares", async () => {
     const myAccount = accounts[1];
@@ -138,17 +161,25 @@ contract('LAOLAND - Ragequit Adapter', async accounts => {
     let dao = await createDao(myAccount);
 
     //Add funds to the Guild Bank after sposoring a member to join the Guild
-    const onboardingAddress = await dao.getAdapterAddress(sha3('onboarding'));
+    const onboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
     const onboarding = await OnboardingContract.at(onboardingAddress);
 
     const votingAddress = await dao.getAdapterAddress(sha3("voting"));
     const voting = await VotingContract.at(votingAddress);
 
-    let proposalId = await submitNewMemberProposal(onboarding, dao, newMember, sharePrice);
+    let proposalId = await submitNewMemberProposal(
+      onboarding,
+      dao,
+      newMember,
+      sharePrice
+    );
 
-    //Sponsor the new proposal, vote and process it 
+    //Sponsor the new proposal, vote and process it
     await sponsorNewMember(onboarding, dao, proposalId, myAccount, voting);
-    await onboarding.processProposal(dao.address, proposalId, { from: myAccount, gasPrice: toBN("0") });
+    await onboarding.processProposal(dao.address, proposalId, {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
 
     //Check Guild Bank Balance
     let guildBalance = await dao.balanceOf(GUILD, ETH_TOKEN);
@@ -162,29 +193,37 @@ contract('LAOLAND - Ragequit Adapter', async accounts => {
     try {
       //Trying to Ragequit with shares + 1 to burn
       await ragequit(dao, 100000000000000001, 0, newMember);
-    } catch (error){
+    } catch (error) {
       assert.equal(error.reason, "insufficient shares");
     }
-  })
+  });
 
   it("should be possible to a member to ragequit when the member has not voted on any proposals yet", async () => {
     const myAccount = accounts[1];
     const newMember = accounts[2];
-    
+
     let dao = await createDao(myAccount);
 
     //Add funds to the Guild Bank after sposoring a member to join the Guild
-    const onboardingAddress = await dao.getAdapterAddress(sha3('onboarding'));
+    const onboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
     const onboarding = await OnboardingContract.at(onboardingAddress);
 
     const votingAddress = await dao.getAdapterAddress(sha3("voting"));
     const voting = await VotingContract.at(votingAddress);
 
-    let proposalId = await submitNewMemberProposal(onboarding, dao, newMember, sharePrice);
+    let proposalId = await submitNewMemberProposal(
+      onboarding,
+      dao,
+      newMember,
+      sharePrice
+    );
 
-    //Sponsor the new proposal to admit the new member, vote and process it 
+    //Sponsor the new proposal to admit the new member, vote and process it
     await sponsorNewMember(onboarding, dao, proposalId, myAccount, voting);
-    await onboarding.processProposal(dao.address, proposalId, { from: myAccount, gasPrice: toBN("0") });
+    await onboarding.processProposal(dao.address, proposalId, {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
 
     //Check Guild Bank Balance
     let guildBalance = await dao.balanceOf(GUILD, ETH_TOKEN);
@@ -200,63 +239,9 @@ contract('LAOLAND - Ragequit Adapter', async accounts => {
     //Check Guild Bank Balance
     let newGuildBalance = await dao.balanceOf(GUILD, ETH_TOKEN);
     assert.equal(toBN(newGuildBalance).toString(), "120"); //must be close to 0
-  })
+  });
 
-it("should be possible to a member to ragequit if the member voted YES on a proposal that is not processed", async () => {
-    const myAccount = accounts[1];
-    const newMember = accounts[2];
-    const applicant = accounts[3];
-
-    let dao = await createDao(myAccount);
-
-    //Add funds to the Guild Bank after sposoring a member to join the Guild
-    const onboardingAddress = await dao.getAdapterAddress(sha3('onboarding'));
-    const onboarding = await OnboardingContract.at(onboardingAddress);
-
-    const financingAddress = await dao.getAdapterAddress(sha3("financing"));
-    const financing = await FinancingContract.at(financingAddress);
-
-    const votingAddress = await dao.getAdapterAddress(sha3("voting"));
-    const voting = await VotingContract.at(votingAddress);
-
-    let proposalId = await submitNewMemberProposal(onboarding, dao, newMember, sharePrice);
-
-    //Sponsor the new proposal to admit the new member, vote and process it 
-    await sponsorNewMember(onboarding, dao, proposalId, myAccount, voting);
-    await onboarding.processProposal(dao.address, proposalId, { from: myAccount, gasPrice: toBN("0") });
-
-    //Check Guild Bank Balance
-    let guildBalance = await dao.balanceOf(GUILD, ETH_TOKEN);
-    assert.equal(guildBalance.toString(), "12000000000000000000".toString());
-
-    //Check New Member Shares
-    let shares = await dao.balanceOf(newMember, SHARES);
-    assert.equal(shares.toString(), "100000000000000000");
-
-    //Create Financing Request
-    let requestedAmount = toBN(50000);
-    await financing.createFinancingRequest(dao.address, applicant, ETH_TOKEN, requestedAmount, fromUtf8(""));
-
-    //Get the new proposalId from event log
-    proposalId = 1;
-    await checkLastEvent(dao, {proposalId})
-
-    //Old Member sponsors the Financing proposal
-    await financing.sponsorProposal(dao.address, proposalId, [], { from: myAccount, gasPrice: toBN("0") });
-
-    //New Member votes YES on the Financing proposal
-    let vote = 1; //YES
-    await voting.submitVote(dao.address, proposalId, vote, { from: newMember, gasPrice: toBN("0") });
-
-    //Ragequit - New member ragequits after YES vote
-    let ragequitContract = await ragequit(dao, shares, 0, newMember);
-
-    //Check Guild Bank Balance
-    let newGuildBalance = await dao.balanceOf(GUILD, ETH_TOKEN);
-    assert.equal(toBN(newGuildBalance).toString(), "120"); //must be close to 0
-  })
-
-  it("should be possible to a member to ragequit if the member voted NO on a proposal that is not processed", async () => {
+  it("should be possible to a member to ragequit if the member voted YES on a proposal that is not processed", async () => {
     const myAccount = accounts[1];
     const newMember = accounts[2];
     const applicant = accounts[3];
@@ -273,7 +258,12 @@ it("should be possible to a member to ragequit if the member voted YES on a prop
     const votingAddress = await dao.getAdapterAddress(sha3("voting"));
     const voting = await VotingContract.at(votingAddress);
 
-    let proposalId = await submitNewMemberProposal(onboarding, dao, newMember, sharePrice);
+    let proposalId = await submitNewMemberProposal(
+      onboarding,
+      dao,
+      newMember,
+      sharePrice
+    );
 
     //Sponsor the new proposal to admit the new member, vote and process it
     await sponsorNewMember(onboarding, dao, proposalId, myAccount, voting);
@@ -302,7 +292,81 @@ it("should be possible to a member to ragequit if the member voted YES on a prop
 
     //Get the new proposalId from event log
     proposalId = 1;
-    checkLastEvent(dao, {proposalId})
+    await checkLastEvent(dao, {proposalId});
+
+    //Old Member sponsors the Financing proposal
+    await financing.sponsorProposal(dao.address, proposalId, [], {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
+
+    //New Member votes YES on the Financing proposal
+    let vote = 1; //YES
+    await voting.submitVote(dao.address, proposalId, vote, {
+      from: newMember,
+      gasPrice: toBN("0"),
+    });
+
+    //Ragequit - New member ragequits after YES vote
+    let ragequitContract = await ragequit(dao, shares, 0, newMember);
+
+    //Check Guild Bank Balance
+    let newGuildBalance = await dao.balanceOf(GUILD, ETH_TOKEN);
+    assert.equal(toBN(newGuildBalance).toString(), "120"); //must be close to 0
+  });
+
+  it("should be possible to a member to ragequit if the member voted NO on a proposal that is not processed", async () => {
+    const myAccount = accounts[1];
+    const newMember = accounts[2];
+    const applicant = accounts[3];
+
+    let dao = await createDao(myAccount);
+
+    //Add funds to the Guild Bank after sposoring a member to join the Guild
+    const onboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
+    const onboarding = await OnboardingContract.at(onboardingAddress);
+
+    const financingAddress = await dao.getAdapterAddress(sha3("financing"));
+    const financing = await FinancingContract.at(financingAddress);
+
+    const votingAddress = await dao.getAdapterAddress(sha3("voting"));
+    const voting = await VotingContract.at(votingAddress);
+
+    let proposalId = await submitNewMemberProposal(
+      onboarding,
+      dao,
+      newMember,
+      sharePrice
+    );
+
+    //Sponsor the new proposal to admit the new member, vote and process it
+    await sponsorNewMember(onboarding, dao, proposalId, myAccount, voting);
+    await onboarding.processProposal(dao.address, proposalId, {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
+
+    //Check Guild Bank Balance
+    let guildBalance = await dao.balanceOf(GUILD, ETH_TOKEN);
+    assert.equal(guildBalance.toString(), "12000000000000000000".toString());
+
+    //Check New Member Shares
+    let shares = await dao.balanceOf(newMember, SHARES);
+    assert.equal(shares.toString(), "100000000000000000");
+
+    //Create Financing Request
+    let requestedAmount = toBN(50000);
+    await financing.createFinancingRequest(
+      dao.address,
+      applicant,
+      ETH_TOKEN,
+      requestedAmount,
+      fromUtf8("")
+    );
+
+    //Get the new proposalId from event log
+    proposalId = 1;
+    checkLastEvent(dao, {proposalId});
 
     //Old Member sponsors the Financing proposal
     await financing.sponsorProposal(dao.address, proposalId, [], {
@@ -323,7 +387,7 @@ it("should be possible to a member to ragequit if the member voted YES on a prop
     //Check Guild Bank Balance
     let newGuildBalance = await dao.balanceOf(GUILD, ETH_TOKEN);
     assert.equal(toBN(newGuildBalance).toString(), "120"); //must be close to 0
-  })
+  });
 
   it("should be possible to an Advisor ragequit at any point in time", async () => {
     const myAccount = accounts[1];
@@ -344,7 +408,6 @@ it("should be possible to a member to ragequit if the member voted YES on a prop
       1,
       oltContract.address
     );
-
 
     // Transfer 1000 OLTs to the Advisor account
     await oltContract.approve(advisorAccount, 100);
@@ -377,16 +440,10 @@ it("should be possible to a member to ragequit if the member voted YES on a prop
 
     // Send a request to join the DAO as an Advisor (non-voting power),
     // the tx passes the OLT ERC20 token, the amount and the nonVotingOnboarding adapter that handles the proposal
-    await onboarding.onboard(
-      dao.address,
-			advisorAccount,
-      LOOT,
-      tokenAmount,
-      {
-        from: advisorAccount,
-        gasPrice: toBN("0"),
-      }
-    );
+    await onboarding.onboard(dao.address, advisorAccount, LOOT, tokenAmount, {
+      from: advisorAccount,
+      gasPrice: toBN("0"),
+    });
 
     let proposalId = 0;
 
@@ -418,12 +475,7 @@ it("should be possible to a member to ragequit if the member voted YES on a prop
     assert.equal(guildBalance.toString(), "10");
 
     //Ragequit - Advisor ragequits
-    await ragequit(
-      dao,
-      0,
-      advisorAccountLoot,
-      advisorAccount
-    );
+    await ragequit(dao, 0, advisorAccountLoot, advisorAccount);
 
     //Check Guild Bank Balance
     let newGuildBalance = await dao.balanceOf(GUILD, oltContract.address);
@@ -442,14 +494,7 @@ it("should be possible to a member to ragequit if the member voted YES on a prop
     let lootSharePrice = 10;
     let chunkSize = 5;
 
-    let dao = await createDao(
-      myAccount,
-      lootSharePrice,
-      chunkSize,
-      10,
-      1
-    );
-
+    let dao = await createDao(myAccount, lootSharePrice, chunkSize, 10, 1);
 
     // Transfer 1000 OLTs to the Advisor account
     const onboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
@@ -467,17 +512,11 @@ it("should be possible to a member to ragequit if the member voted YES on a prop
 
     // Send a request to join the DAO as an Advisor (non-voting power),
     // the tx passes the OLT ERC20 token, the amount and the nonVotingOnboarding adapter that handles the proposal
-    await onboarding.onboard(
-      dao.address,
-			memberAccount,
-      SHARES,
-      tokenAmount,
-      {
-        from: myAccount,
-        value: tokenAmount,
-        gasPrice: toBN("0"),
-      }
-    );
+    await onboarding.onboard(dao.address, memberAccount, SHARES, tokenAmount, {
+      from: myAccount,
+      value: tokenAmount,
+      gasPrice: toBN("0"),
+    });
 
     let proposalId = 0;
 
@@ -504,25 +543,24 @@ it("should be possible to a member to ragequit if the member voted YES on a prop
     let ragequitContract = await RagequitContract.at(ragequitAddress);
 
     const shares = await dao.balanceOf(memberAccount, SHARES);
-    await ragequitContract.startRagequit(dao.address, toBN(Math.floor(shares / 2)), toBN(0), {
-      from: memberAccount,
-      gasPrice: toBN("0"),
-    }); // we are not burning all the shares so we are still members once it is done
-
-    await onboarding.onboard(
+    await ragequitContract.startRagequit(
       dao.address,
-			otherAccount,
-      SHARES,
-      tokenAmount,
+      toBN(Math.floor(shares / 2)),
+      toBN(0),
       {
-        from: myAccount,
-        value: tokenAmount,
+        from: memberAccount,
         gasPrice: toBN("0"),
       }
-    );
-  
+    ); // we are not burning all the shares so we are still members once it is done
+
+    await onboarding.onboard(dao.address, otherAccount, SHARES, tokenAmount, {
+      from: myAccount,
+      value: tokenAmount,
+      gasPrice: toBN("0"),
+    });
+
     proposalId = 1;
-  
+
     // Sponsor the new proposal to allow the Advisor to join the DAO
     try {
       await onboarding.sponsorProposal(dao.address, proposalId, [], {
@@ -530,16 +568,16 @@ it("should be possible to a member to ragequit if the member voted YES on a prop
         gasPrice: toBN("0"),
       });
       throw new Error("should fail");
-    } catch( err ) {
-      assert.equal(err.message.indexOf('onlyMember') > -1, true);
+    } catch (err) {
+      assert.equal(err.message.indexOf("onlyMember") > -1, true);
     }
-    
+
     await ragequitContract.burnShares(dao.address, memberAccount, 2, {
       gasPrice: toBN("0"),
     });
-  
+
     // member can vote again!
-    
+
     await onboarding.sponsorProposal(dao.address, proposalId, [], {
       from: memberAccount,
       gasPrice: toBN("0"),

--- a/test/core/registry.test.js
+++ b/test/core/registry.test.js
@@ -1,5 +1,5 @@
 // Whole-script strict mode syntax
-'use strict';
+"use strict";
 
 /**
 MIT License
@@ -25,12 +25,17 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
 const DaoRegistry = artifacts.require("./core/DaoRegistry");
-const FlagHelperLib = artifacts.require('./helpers/FlagHelper');
+const FlagHelperLib = artifacts.require("./helpers/FlagHelper");
 
-const {sha3, toBN, fromUtf8, createDao, OnboardingContract} = require('../../utils/DaoFactory.js');
+const {
+  sha3,
+  toBN,
+  fromUtf8,
+  createDao,
+  OnboardingContract,
+} = require("../../utils/DaoFactory.js");
 
-contract('Registry', async (accounts) => {
-
+contract("Registry", async (accounts) => {
   it("should not be possible to add a module with invalid id", async () => {
     let lib = await FlagHelperLib.new();
     await DaoRegistry.link("FlagHelper", lib.address);
@@ -85,7 +90,11 @@ contract('Registry', async (accounts) => {
 
     try {
       //Try to add another module using the same id 1
-      await registry.addAdapter(moduleId, "0xd7bCe30D77DE56E3D21AEfe7ad144b3134438F5B", 0);
+      await registry.addAdapter(
+        moduleId,
+        "0xd7bCe30D77DE56E3D21AEfe7ad144b3134438F5B",
+        0
+      );
     } catch (error) {
       assert.equal(error.reason, "adapterId already in use");
     }
@@ -139,7 +148,7 @@ contract('Registry', async (accounts) => {
     const delegateKey = accounts[2];
     let dao = await createDao(myAccount);
 
-    const onboardingAddr = await dao.getAdapterAddress(sha3('onboarding'));
+    const onboardingAddr = await dao.getAdapterAddress(sha3("onboarding"));
     const onboarding = await OnboardingContract.at(onboardingAddr);
 
     const myAccountActive1 = await dao.isActiveMember(myAccount);
@@ -148,7 +157,10 @@ contract('Registry', async (accounts) => {
     assert.equal(true, myAccountActive1);
     assert.equal(false, delegateKeyActive1);
 
-    await onboarding.updateDelegateKey(dao.address, delegateKey, { from: myAccount, gasPrice: toBN("0") });
+    await onboarding.updateDelegateKey(dao.address, delegateKey, {
+      from: myAccount,
+      gasPrice: toBN("0"),
+    });
 
     const myAccountActive2 = await dao.isActiveMember(myAccount);
     const delegateKeyActive2 = await dao.isActiveMember(delegateKey);

--- a/utils/DaoFactory.js
+++ b/utils/DaoFactory.js
@@ -1,5 +1,5 @@
 // Whole-script strict mode syntax
-'use strict';
+"use strict";
 
 /**
 MIT License
@@ -106,11 +106,12 @@ async function addDefaultAdapters(
     }),
     entry("guildkick", guildkick, {
       SUBMIT_PROPOSAL: true,
-      PROCESS_PROPOSAL: true,
       SPONSOR_PROPOSAL: true,
+      PROCESS_PROPOSAL: true,
       SUB_FROM_BALANCE: true,
       ADD_TO_BALANCE: true,
       JAIL_MEMBER: true,
+      UNJAIL_MEMBER: true,
       INTERNAL_TRANSFER: true,
     }),
     entry("managing", managing, {
@@ -161,7 +162,8 @@ async function createDao(
   nbShares = numberOfShares,
   votingPeriod = 10,
   gracePeriod = 1,
-  tokenAddr = ETH_TOKEN
+  tokenAddr = ETH_TOKEN,
+  
 ) {
   let lib = await FlagHelperLib.new();
   await DaoRegistry.link("FlagHelper", lib.address);


### PR DESCRIPTION
Closes #57 

Scenario:
As a DAO member I want to be able to transfer the remaining funds to the kicked member, after the guild kick proposal has passed. Any member of the DAO that has voting power is allowed to trigger the funds transfer, this operation is known as ragekick - it forces the kicked member to redeem their proportional share of tokens that were locked after the guild kick proposal was approved. This is effectively the same thing as the kicked member calling ragequit themselves.

Test Cases:
 - [x] should be possible to kick a DAO member and call the ragekick to return the funds to the kicked member
 - [x] a kicked member should not have any remaining SHARES or LOOT after the ragekick is processed
 - [x] should not be possible to process a ragekick if the caller is not a DAO member
 - [x] should not be possible to process a ragekick if the proposal does not exist
 - [x] should not be possible to process a ragekick if the proposal status is not DONE
 - [x] should not be possible to process a ragekick if the batch index is smaller than the current processing index
 - [ ] should be possible to process a ragekick even if the process consumes more gas than the block gas limit (large number of allowed tokens in the bank) - This TC will be addressed in another ticket (https://github.com/openlawteam/laoland/issues/93)