### PR TITLE
GH-96 - Multi-token support for Financing requests

### DIFF
--- a/contracts/adapters/Financing.sol
+++ b/contracts/adapters/Financing.sol
@@ -61,10 +61,7 @@ contract FinancingContract is IFinancing, DaoConstants, MemberGuard {
         bytes32 details
     ) external override returns (uint256) {
         require(amount > 0, "invalid requested amount");
-        require(
-            dao.isTokenAllowed(token),
-            "token not allowed"
-        );
+        require(dao.isTokenAllowed(token), "token not allowed");
         require(
             dao.isNotReservedAddress(applicant),
             "applicant using reserved address"

--- a/contracts/adapters/Financing.sol
+++ b/contracts/adapters/Financing.sol
@@ -61,8 +61,10 @@ contract FinancingContract is IFinancing, DaoConstants, MemberGuard {
         bytes32 details
     ) external override returns (uint256) {
         require(amount > 0, "invalid requested amount");
-        require(token == address(0x0), "only raw eth token is supported");
-        //TODO (fforbeck): check if other types of tokens are supported/allowed
+        require(
+            dao.isTokenAllowed(token),
+            "token not allowed"
+        );
         require(
             dao.isNotReservedAddress(applicant),
             "applicant using reserved address"

--- a/contracts/core/DaoRegistry.sol
+++ b/contracts/core/DaoRegistry.sol
@@ -351,6 +351,10 @@ contract DaoRegistry is DaoConstants, AdapterGuard {
         return _bank.availableInternalTokens[tokenToMint];
     }
 
+    function isTokenAllowed(address token) external view returns (bool) {
+        return _bank.availableTokens[token];
+    }
+
     /*
      * MEMBERS
      */

--- a/test/adapters/financing.test.js
+++ b/test/adapters/financing.test.js
@@ -38,7 +38,7 @@ const {
   FinancingContract,
   ETH_TOKEN,
 } = require("../../utils/DaoFactory.js");
-const { checkLastEvent, checkBalance } = require("../../utils/TestUtils.js");
+const {checkLastEvent, checkBalance} = require("../../utils/TestUtils.js");
 const remaining = sharePrice.sub(toBN("50000000000000"));
 
 contract("LAOLAND - Financing Adapter", async (accounts) => {
@@ -68,7 +68,7 @@ contract("LAOLAND - Financing Adapter", async (accounts) => {
 
     //Get the new proposal id
     let proposalId = "0";
-    await checkLastEvent(dao, { proposalId });
+    await checkLastEvent(dao, {proposalId});
 
     //Sponsor the new proposal, vote and process it
     await onboarding.sponsorProposal(dao.address, proposalId, [], {
@@ -105,12 +105,12 @@ contract("LAOLAND - Financing Adapter", async (accounts) => {
       ETH_TOKEN,
       requestedAmount,
       fromUtf8(""),
-      { gasPrice: toBN("0") }
+      {gasPrice: toBN("0")}
     );
 
     //Get the new proposalId from event log
     proposalId = "1";
-    await checkLastEvent(dao, { proposalId });
+    await checkLastEvent(dao, {proposalId});
 
     //Member sponsors the Financing proposal
     await financing.sponsorProposal(dao.address, proposalId, [], {
@@ -166,7 +166,7 @@ contract("LAOLAND - Financing Adapter", async (accounts) => {
 
     //Get the new proposal id
     let proposalId = "0";
-    await checkLastEvent(dao, { proposalId });
+    await checkLastEvent(dao, {proposalId});
 
     //Sponsor the new proposal, vote and process it
     await onboarding.sponsorProposal(dao.address, proposalId, [], {
@@ -196,7 +196,7 @@ contract("LAOLAND - Financing Adapter", async (accounts) => {
 
     //Get the new proposalId from event log
     proposalId = "1";
-    await checkLastEvent(dao, { proposalId });
+    await checkLastEvent(dao, {proposalId});
 
     //Member sponsors the Financing proposal
     await financing.sponsorProposal(dao.address, proposalId, [], {
@@ -243,7 +243,7 @@ contract("LAOLAND - Financing Adapter", async (accounts) => {
 
     //Get the new proposal id
     let proposalId = "0";
-    await checkLastEvent(dao, { proposalId });
+    await checkLastEvent(dao, {proposalId});
 
     //Sponsor the new proposal, vote and process it
     await onboarding.sponsorProposal(dao.address, proposalId, [], {
@@ -301,7 +301,7 @@ contract("LAOLAND - Financing Adapter", async (accounts) => {
 
     //Get the new proposal id
     let proposalId = "0";
-    await checkLastEvent(dao, { proposalId });
+    await checkLastEvent(dao, {proposalId});
 
     //Sponsor the new proposal, vote and process it
     await onboarding.sponsorProposal(dao.address, proposalId, [], {


### PR DESCRIPTION
Closes #96 

Scenario:
As an individual that wants to submit Financing proposal to the DAO, I want to be able to request the funds in any available token in the DAORegistry, not only ETH. If I want to receive funds in different tokens I may submit different proposals for each one of the tokens.

Tests:
 - [x] should be possible to request funding in ETH
 - [x] should be possible to request funding in any token available in DAO (dao._bank.availableTokens)
 - [x] should not be possible to send a funding proposal with the funding amount equals to zero