### PR TITLE
GH-94 - Using CloneFactory pattern to make it cheaper to deploy new DAOs

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -13,6 +13,7 @@
     "code-complexity": [
       "warn",
       7
-    ]
+    ],
+    "no-inline-assembly": "warn"
   }
 }

--- a/contracts/core/CloneFactory.sol
+++ b/contracts/core/CloneFactory.sol
@@ -26,32 +26,50 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //solhint-disable no-inline-assembly
 
 contract CloneFactory {
-
-  function _createClone(address target) internal returns (address payable result) {
-    bytes20 targetBytes = bytes20(target);
-    assembly {
-      let clone := mload(0x40)
-      mstore(clone, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
-      mstore(add(clone, 0x14), targetBytes)
-      mstore(add(clone, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
-      result := create(0, clone, 0x37)
+    function _createClone(address target)
+        internal
+        returns (address payable result)
+    {
+        bytes20 targetBytes = bytes20(target);
+        assembly {
+            let clone := mload(0x40)
+            mstore(
+                clone,
+                0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000
+            )
+            mstore(add(clone, 0x14), targetBytes)
+            mstore(
+                add(clone, 0x28),
+                0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000
+            )
+            result := create(0, clone, 0x37)
+        }
     }
-  }
 
-  function _isClone(address target, address query) internal view returns (bool result) {
-    bytes20 targetBytes = bytes20(target);
-    assembly {
-      let clone := mload(0x40)
-      mstore(clone, 0x363d3d373d3d3d363d7300000000000000000000000000000000000000000000)
-      mstore(add(clone, 0xa), targetBytes)
-      mstore(add(clone, 0x1e), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
+    function _isClone(address target, address query)
+        internal
+        view
+        returns (bool result)
+    {
+        bytes20 targetBytes = bytes20(target);
+        assembly {
+            let clone := mload(0x40)
+            mstore(
+                clone,
+                0x363d3d373d3d3d363d7300000000000000000000000000000000000000000000
+            )
+            mstore(add(clone, 0xa), targetBytes)
+            mstore(
+                add(clone, 0x1e),
+                0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000
+            )
 
-      let other := add(clone, 0x40)
-      extcodecopy(query, other, 0, 0x2d)
-      result := and(
-        eq(mload(clone), mload(other)),
-        eq(mload(add(clone, 0xd)), mload(add(other, 0xd)))
-      )
+            let other := add(clone, 0x40)
+            extcodecopy(query, other, 0, 0x2d)
+            result := and(
+                eq(mload(clone), mload(other)),
+                eq(mload(add(clone, 0xd)), mload(add(other, 0xd)))
+            )
+        }
     }
-  }
 }

--- a/contracts/core/CloneFactory.sol
+++ b/contracts/core/CloneFactory.sol
@@ -27,7 +27,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 contract CloneFactory {
 
-  function createClone(address target) internal returns (address result) {
+  function _createClone(address target) internal returns (address result) {
     bytes20 targetBytes = bytes20(target);
     assembly {
       let clone := mload(0x40)
@@ -38,7 +38,7 @@ contract CloneFactory {
     }
   }
 
-  function isClone(address target, address query) internal view returns (bool result) {
+  function _isClone(address target, address query) internal view returns (bool result) {
     bytes20 targetBytes = bytes20(target);
     assembly {
       let clone := mload(0x40)

--- a/contracts/core/CloneFactory.sol
+++ b/contracts/core/CloneFactory.sol
@@ -27,7 +27,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 contract CloneFactory {
 
-  function _createClone(address target) internal returns (address result) {
+  function _createClone(address target) internal returns (address payable result) {
     bytes20 targetBytes = bytes20(target);
     assembly {
       let clone := mload(0x40)

--- a/contracts/core/CloneFactory.sol
+++ b/contracts/core/CloneFactory.sol
@@ -1,0 +1,57 @@
+pragma solidity ^0.7.0;
+
+// SPDX-License-Identifier: MIT
+
+/*
+The MIT License (MIT)
+Copyright (c) 2018 Murray Software, LLC.
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+//solhint-disable max-line-length
+//solhint-disable no-inline-assembly
+
+contract CloneFactory {
+
+  function createClone(address target) internal returns (address result) {
+    bytes20 targetBytes = bytes20(target);
+    assembly {
+      let clone := mload(0x40)
+      mstore(clone, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
+      mstore(add(clone, 0x14), targetBytes)
+      mstore(add(clone, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
+      result := create(0, clone, 0x37)
+    }
+  }
+
+  function isClone(address target, address query) internal view returns (bool result) {
+    bytes20 targetBytes = bytes20(target);
+    assembly {
+      let clone := mload(0x40)
+      mstore(clone, 0x363d3d373d3d3d363d7300000000000000000000000000000000000000000000)
+      mstore(add(clone, 0xa), targetBytes)
+      mstore(add(clone, 0x1e), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
+
+      let other := add(clone, 0x40)
+      extcodecopy(query, other, 0, 0x2d)
+      result := and(
+        eq(mload(clone), mload(other)),
+        eq(mload(add(clone, 0xd)), mload(add(other, 0xd)))
+      )
+    }
+  }
+}

--- a/contracts/core/DaoFactory.sol
+++ b/contracts/core/DaoFactory.sol
@@ -5,6 +5,7 @@ pragma experimental ABIEncoderV2;
 
 import "./DaoConstants.sol";
 import "./DaoRegistry.sol";
+import "./CloneFactory.sol";
 import "../adapters/Onboarding.sol";
 
 /**
@@ -31,11 +32,20 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
 
-contract DaoFactory is DaoConstants {
+contract DaoFactory is CloneFactory, DaoConstants {
     struct Adapter {
         bytes32 id;
         address addr;
         uint256 flags;
+    }
+
+    event LAOCreated(address laoAddress);
+
+    //TODO ACL?
+    function newDao(address _libraryAddress) external {
+        address clone = _createClone(_libraryAddress);
+        DaoRegistry(clone).init(msg.sender);
+        emit LAOCreated(clone);
     }
 
     /*
@@ -65,4 +75,5 @@ contract DaoFactory is DaoConstants {
         dao.removeAdapter(adapter.id);
         dao.addAdapter(adapter.id, adapter.addr, adapter.flags);
     }
+
 }

--- a/contracts/core/DaoFactory.sol
+++ b/contracts/core/DaoFactory.sol
@@ -57,7 +57,6 @@ contract DaoFactory is CloneFactory, DaoConstants {
     function addAdapters(DaoRegistry dao, Adapter[] calldata adapters)
         external
     {
-        emit Debug("add adapters");
         //Registring Adapters
         require(
             dao.state() == DaoRegistry.DaoState.CREATION,

--- a/contracts/core/DaoFactory.sol
+++ b/contracts/core/DaoFactory.sol
@@ -42,7 +42,7 @@ contract DaoFactory is CloneFactory, DaoConstants {
     event DAOCreated(address _address);
     event Debug(string msg);
 
-     //TODO: ACL? onlyOwner?
+    //TODO: ACL? onlyOwner?
     function newDao(address _libraryAddress) external {
         DaoRegistry dao = DaoRegistry(_createClone(_libraryAddress));
         dao.initialize(msg.sender);
@@ -68,7 +68,7 @@ contract DaoFactory is CloneFactory, DaoConstants {
         }
     }
 
-     //TODO: ACL? onlyOwner?
+    //TODO: ACL? onlyOwner?
     function updateAdapter(DaoRegistry dao, Adapter calldata adapter) external {
         require(
             dao.state() == DaoRegistry.DaoState.CREATION,
@@ -78,5 +78,4 @@ contract DaoFactory is CloneFactory, DaoConstants {
         dao.removeAdapter(adapter.id);
         dao.addAdapter(adapter.id, adapter.addr, adapter.flags);
     }
-
 }

--- a/contracts/core/DaoFactory.sol
+++ b/contracts/core/DaoFactory.sol
@@ -41,11 +41,11 @@ contract DaoFactory is CloneFactory, DaoConstants {
 
     event LAOCreated(address laoAddress);
 
-    //TODO ACL?
+    //TODO: ACL?
     function newDao(address _libraryAddress) external {
-        address clone = _createClone(_libraryAddress);
-        DaoRegistry(clone).init(msg.sender);
-        emit LAOCreated(clone);
+        DaoRegistry dao = DaoRegistry(_createClone(_libraryAddress));
+        dao.initialize(msg.sender);
+        emit LAOCreated(address(dao));
     }
 
     /*

--- a/contracts/core/DaoFactory.sol
+++ b/contracts/core/DaoFactory.sol
@@ -40,22 +40,24 @@ contract DaoFactory is CloneFactory, DaoConstants {
     }
 
     event DAOCreated(address _address);
+    event Debug(string msg);
 
-    //TODO: ACL?
-    function newDao(address _libraryAddress) external returns (address newDaoAddress) {
+     //TODO: ACL? onlyOwner?
+    function newDao(address _libraryAddress) external {
         DaoRegistry dao = DaoRegistry(_createClone(_libraryAddress));
         dao.initialize(msg.sender);
         emit DAOCreated(address(dao));
-        return address(dao);
     }
 
     /*
      * @dev: A new DAO is instantiated with only the Core Modules enabled, to reduce the call cost.
      *       Another call must be made to enable the default Adapters, see @registerDefaultAdapters.
      */
+    //TODO: ACL? onlyOwner?
     function addAdapters(DaoRegistry dao, Adapter[] calldata adapters)
         external
     {
+        emit Debug("add adapters");
         //Registring Adapters
         require(
             dao.state() == DaoRegistry.DaoState.CREATION,
@@ -67,6 +69,7 @@ contract DaoFactory is CloneFactory, DaoConstants {
         }
     }
 
+     //TODO: ACL? onlyOwner?
     function updateAdapter(DaoRegistry dao, Adapter calldata adapter) external {
         require(
             dao.state() == DaoRegistry.DaoState.CREATION,

--- a/contracts/core/DaoFactory.sol
+++ b/contracts/core/DaoFactory.sol
@@ -39,13 +39,14 @@ contract DaoFactory is CloneFactory, DaoConstants {
         uint256 flags;
     }
 
-    event LAOCreated(address laoAddress);
+    event DAOCreated(address _address);
 
     //TODO: ACL?
-    function newDao(address _libraryAddress) external {
+    function newDao(address _libraryAddress) external returns (address newDaoAddress) {
         DaoRegistry dao = DaoRegistry(_createClone(_libraryAddress));
         dao.initialize(msg.sender);
-        emit LAOCreated(address(dao));
+        emit DAOCreated(address(dao));
+        return address(dao);
     }
 
     /*

--- a/contracts/core/DaoRegistry.sol
+++ b/contracts/core/DaoRegistry.sol
@@ -33,7 +33,7 @@ SOFTWARE.
  */
 
 contract DaoRegistry is DaoConstants, AdapterGuard {
-    bool private initialized; // internally tracks deployment under eip-1167 proxy pattern
+    bool private _initialized; // internally tracks deployment under eip-1167 proxy pattern
     
     /*
      * LIBRARIES
@@ -135,7 +135,7 @@ contract DaoRegistry is DaoConstants, AdapterGuard {
     // }
 
     function initialize(address creator) external {
-        require(!initialized, "dao already initialized");
+        require(!_initialized, "dao already initialized");
         
         address memberAddr = creator;
         Member storage member = members[memberAddr];
@@ -148,7 +148,7 @@ contract DaoRegistry is DaoConstants, AdapterGuard {
         _createNewAmountCheckpoint(memberAddr, SHARES, 1);
         _createNewAmountCheckpoint(TOTAL, SHARES, 1);
         
-        initialized = true;
+        _initialized = true;
     }
 
     receive() external payable {

--- a/contracts/core/DaoRegistry.sol
+++ b/contracts/core/DaoRegistry.sol
@@ -33,7 +33,7 @@ SOFTWARE.
  */
 
 contract DaoRegistry is DaoConstants, AdapterGuard {
-    bool private _initialized; // internally tracks deployment under eip-1167 proxy pattern
+    bool public initialized = false; // internally tracks deployment under eip-1167 proxy pattern
     
     /*
      * LIBRARIES
@@ -117,7 +117,7 @@ contract DaoRegistry is DaoConstants, AdapterGuard {
     mapping(address => mapping(uint32 => DelegateCheckpoint)) checkpoints;
     mapping(address => uint32) numCheckpoints;
 
-    DaoState public state = DaoState.CREATION;
+    DaoState public state;
 
     /// @notice The number of proposals submitted to the DAO
     uint64 public proposalCount;
@@ -134,9 +134,11 @@ contract DaoRegistry is DaoConstants, AdapterGuard {
     // constructor() {
     // }
 
+    //TODO: we may need to add some ACL to ensure only the factory is allowed to clone it, otherwise
+    //any will able to deploy it, and the first one to call this function is added to the DAO as a member.
     function initialize(address creator) external {
-        require(!_initialized, "dao already initialized");
-        
+        require(!initialized, "dao already initialized");
+
         address memberAddr = creator;
         Member storage member = members[memberAddr];
         member.flags = member.flags.setFlag(FlagHelper.Flag.EXISTS, true);
@@ -148,7 +150,7 @@ contract DaoRegistry is DaoConstants, AdapterGuard {
         _createNewAmountCheckpoint(memberAddr, SHARES, 1);
         _createNewAmountCheckpoint(TOTAL, SHARES, 1);
         
-        _initialized = true;
+        initialized = true;
     }
 
     receive() external payable {

--- a/contracts/core/DaoRegistry.sol
+++ b/contracts/core/DaoRegistry.sol
@@ -2,9 +2,9 @@ pragma solidity ^0.7.0;
 
 // SPDX-License-Identifier: MIT
 
+import "./DaoConstants.sol";
 import "../helpers/FlagHelper.sol";
 import "../utils/SafeMath.sol";
-import "./DaoConstants.sol";
 import "../guards/AdapterGuard.sol";
 import "../utils/IERC20.sol";
 
@@ -129,6 +129,10 @@ contract DaoRegistry is DaoConstants, AdapterGuard {
     mapping(bytes32 => uint256) public configuration;
 
     constructor() {
+       init(msg.sender);
+    }
+    //FIXME
+    function init(address creator) external {
         address memberAddr = msg.sender;
         Member storage member = members[memberAddr];
         member.flags = member.flags.setFlag(FlagHelper.Flag.EXISTS, true);

--- a/contracts/core/DaoRegistry.sol
+++ b/contracts/core/DaoRegistry.sol
@@ -130,11 +130,11 @@ contract DaoRegistry is DaoConstants, AdapterGuard {
     /// @notice The map that keeps track of configuration parameters for the DAO and adapters
     mapping(bytes32 => uint256) public configuration;
 
-    constructor() {
-       init(msg.sender);
-    }
+    /// @notice Clonable contract must have an empty constructor
+    // constructor() {
+    // }
 
-    function init(address creator) external {
+    function initialize(address creator) external {
         require(!initialized, "dao already initialized");
         
         address memberAddr = creator;

--- a/contracts/core/DaoRegistry.sol
+++ b/contracts/core/DaoRegistry.sol
@@ -34,7 +34,7 @@ SOFTWARE.
 
 contract DaoRegistry is DaoConstants, AdapterGuard {
     bool public initialized = false; // internally tracks deployment under eip-1167 proxy pattern
-    
+
     /*
      * LIBRARIES
      */
@@ -149,7 +149,7 @@ contract DaoRegistry is DaoConstants, AdapterGuard {
 
         _createNewAmountCheckpoint(memberAddr, SHARES, 1);
         _createNewAmountCheckpoint(TOTAL, SHARES, 1);
-        
+
         initialized = true;
     }
 

--- a/contracts/core/DaoRegistry.sol
+++ b/contracts/core/DaoRegistry.sol
@@ -33,6 +33,8 @@ SOFTWARE.
  */
 
 contract DaoRegistry is DaoConstants, AdapterGuard {
+    bool private initialized; // internally tracks deployment under eip-1167 proxy pattern
+    
     /*
      * LIBRARIES
      */
@@ -131,9 +133,11 @@ contract DaoRegistry is DaoConstants, AdapterGuard {
     constructor() {
        init(msg.sender);
     }
-    //FIXME
+
     function init(address creator) external {
-        address memberAddr = msg.sender;
+        require(!initialized, "dao already initialized");
+        
+        address memberAddr = creator;
         Member storage member = members[memberAddr];
         member.flags = member.flags.setFlag(FlagHelper.Flag.EXISTS, true);
         memberAddressesByDelegatedKey[memberAddr] = memberAddr;
@@ -143,6 +147,8 @@ contract DaoRegistry is DaoConstants, AdapterGuard {
 
         _createNewAmountCheckpoint(memberAddr, SHARES, 1);
         _createNewAmountCheckpoint(TOTAL, SHARES, 1);
+        
+        initialized = true;
     }
 
     receive() external payable {

--- a/test/adapters/offchain.voting.test.js
+++ b/test/adapters/offchain.voting.test.js
@@ -59,7 +59,7 @@ async function createOffchainVotingDao(
   let lib = await FlagHelperLib.new();
   const daoFactory = await DaoFactory.new();
   await DaoRegistry.link("FlagHelper", lib.address);
-  let dao = await DaoRegistry.new({ from: senderAccount, gasPrice: toBN("0") });
+  let dao = await DaoRegistry.new({from: senderAccount, gasPrice: toBN("0")});
   await dao.initialize(senderAccount, {
     from: senderAccount,
     gasPrice: toBN("0"),
@@ -78,14 +78,14 @@ async function createOffchainVotingDao(
 
   await offchainVoting.configureDao(dao.address, votingPeriod, gracePeriod, 10);
   await dao.finalizeDao();
-  return { dao, voting: offchainVoting };
+  return {dao, voting: offchainVoting};
 }
 
 contract("LAOLAND - Offchain Voting Module", async (accounts) => {
   it("should be possible to vote offchain", async () => {
     const myAccount = accounts[1];
     const otherAccount = accounts[2];
-    let { dao, voting } = await createOffchainVotingDao(myAccount);
+    let {dao, voting} = await createOffchainVotingDao(myAccount);
 
     const onboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
     const onboarding = await OnboardingContract.at(onboardingAddress);
@@ -106,7 +106,7 @@ contract("LAOLAND - Offchain Voting Module", async (accounts) => {
       dao.address,
       0,
       web3.eth.abi.encodeParameter("uint256", blockNumber),
-      { from: myAccount, gasPrice: toBN("0") }
+      {from: myAccount, gasPrice: toBN("0")}
     );
 
     const voteElements = await addVote(
@@ -117,7 +117,7 @@ contract("LAOLAND - Offchain Voting Module", async (accounts) => {
       myAccount,
       true
     );
-    const { voteResultTree, votes } = prepareVoteResult(voteElements);
+    const {voteResultTree, votes} = prepareVoteResult(voteElements);
     const result = toStepNode(votes[0], voteResultTree);
 
     await voting.submitVoteResult(
@@ -125,7 +125,7 @@ contract("LAOLAND - Offchain Voting Module", async (accounts) => {
       0,
       voteResultTree.getHexRoot(),
       result,
-      { from: myAccount, gasPrice: toBN("0") }
+      {from: myAccount, gasPrice: toBN("0")}
     );
     await advanceTime(10000);
     await onboarding.processProposal(dao.address, 0, {
@@ -139,7 +139,7 @@ contract("LAOLAND - Offchain Voting Module", async (accounts) => {
     const otherAccount = accounts[2];
     const otherAccount2 = accounts[3];
 
-    let { dao, voting } = await createOffchainVotingDao(myAccount);
+    let {dao, voting} = await createOffchainVotingDao(myAccount);
 
     const onboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
     const onboarding = await OnboardingContract.at(onboardingAddress);
@@ -172,13 +172,13 @@ contract("LAOLAND - Offchain Voting Module", async (accounts) => {
       dao.address,
       0,
       web3.eth.abi.encodeParameter("uint256", blockNumber),
-      { from: myAccount, gasPrice: toBN("0") }
+      {from: myAccount, gasPrice: toBN("0")}
     );
     await onboarding.sponsorProposal(
       dao.address,
       1,
       web3.eth.abi.encodeParameter("uint256", blockNumber),
-      { from: myAccount, gasPrice: toBN("0") }
+      {from: myAccount, gasPrice: toBN("0")}
     );
 
     const voteElements = await addVote(
@@ -208,14 +208,14 @@ contract("LAOLAND - Offchain Voting Module", async (accounts) => {
       0,
       r1.voteResultTree.getHexRoot(),
       result1,
-      { from: myAccount, gasPrice: toBN("0") }
+      {from: myAccount, gasPrice: toBN("0")}
     );
     await voting.submitVoteResult(
       dao.address,
       1,
       r2.voteResultTree.getHexRoot(),
       result2,
-      { from: myAccount, gasPrice: toBN("0") }
+      {from: myAccount, gasPrice: toBN("0")}
     );
     await advanceTime(10000);
     await onboarding.processProposal(dao.address, 0, {
@@ -247,7 +247,7 @@ contract("LAOLAND - Offchain Voting Module", async (accounts) => {
       dao.address,
       proposalId,
       web3.eth.abi.encodeParameter("uint256", blockNumber),
-      { from: myAccount, gasPrice: toBN("0") }
+      {from: myAccount, gasPrice: toBN("0")}
     );
     let ve = await addVote([], blockNumber, dao, proposalId, myAccount, true);
     ve = await addVote(ve, blockNumber, dao, proposalId, otherAccount, true);
@@ -263,7 +263,7 @@ contract("LAOLAND - Offchain Voting Module", async (accounts) => {
       proposalId,
       voteResultTree2.getHexRoot(),
       result3,
-      { from: myAccount, gasPrice: toBN("0") }
+      {from: myAccount, gasPrice: toBN("0")}
     );
 
     const nodePrevious = toStepNode(votes2[0], voteResultTree2);

--- a/test/adapters/offchain.voting.test.js
+++ b/test/adapters/offchain.voting.test.js
@@ -59,7 +59,11 @@ async function createOffchainVotingDao(
   let lib = await FlagHelperLib.new();
   const daoFactory = await DaoFactory.new();
   await DaoRegistry.link("FlagHelper", lib.address);
-  let dao = await DaoRegistry.new({from: senderAccount, gasPrice: toBN("0")});
+  let dao = await DaoRegistry.new({ from: senderAccount, gasPrice: toBN("0") });
+  await dao.initialize(senderAccount, {
+    from: senderAccount,
+    gasPrice: toBN("0"),
+  });
   await addDefaultAdapters(dao, unitPrice, nbShares, votingPeriod, gracePeriod);
   const votingAddress = await dao.getAdapterAddress(sha3("voting"));
   const offchainVoting = await OffchainVotingContract.new(votingAddress);
@@ -74,14 +78,14 @@ async function createOffchainVotingDao(
 
   await offchainVoting.configureDao(dao.address, votingPeriod, gracePeriod, 10);
   await dao.finalizeDao();
-  return {dao, voting: offchainVoting};
+  return { dao, voting: offchainVoting };
 }
 
 contract("LAOLAND - Offchain Voting Module", async (accounts) => {
   it("should be possible to vote offchain", async () => {
     const myAccount = accounts[1];
     const otherAccount = accounts[2];
-    let {dao, voting} = await createOffchainVotingDao(myAccount);
+    let { dao, voting } = await createOffchainVotingDao(myAccount);
 
     const onboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
     const onboarding = await OnboardingContract.at(onboardingAddress);
@@ -102,7 +106,7 @@ contract("LAOLAND - Offchain Voting Module", async (accounts) => {
       dao.address,
       0,
       web3.eth.abi.encodeParameter("uint256", blockNumber),
-      {from: myAccount, gasPrice: toBN("0")}
+      { from: myAccount, gasPrice: toBN("0") }
     );
 
     const voteElements = await addVote(
@@ -113,7 +117,7 @@ contract("LAOLAND - Offchain Voting Module", async (accounts) => {
       myAccount,
       true
     );
-    const {voteResultTree, votes} = prepareVoteResult(voteElements);
+    const { voteResultTree, votes } = prepareVoteResult(voteElements);
     const result = toStepNode(votes[0], voteResultTree);
 
     await voting.submitVoteResult(
@@ -121,7 +125,7 @@ contract("LAOLAND - Offchain Voting Module", async (accounts) => {
       0,
       voteResultTree.getHexRoot(),
       result,
-      {from: myAccount, gasPrice: toBN("0")}
+      { from: myAccount, gasPrice: toBN("0") }
     );
     await advanceTime(10000);
     await onboarding.processProposal(dao.address, 0, {
@@ -135,7 +139,7 @@ contract("LAOLAND - Offchain Voting Module", async (accounts) => {
     const otherAccount = accounts[2];
     const otherAccount2 = accounts[3];
 
-    let {dao, voting} = await createOffchainVotingDao(myAccount);
+    let { dao, voting } = await createOffchainVotingDao(myAccount);
 
     const onboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
     const onboarding = await OnboardingContract.at(onboardingAddress);
@@ -168,13 +172,13 @@ contract("LAOLAND - Offchain Voting Module", async (accounts) => {
       dao.address,
       0,
       web3.eth.abi.encodeParameter("uint256", blockNumber),
-      {from: myAccount, gasPrice: toBN("0")}
+      { from: myAccount, gasPrice: toBN("0") }
     );
     await onboarding.sponsorProposal(
       dao.address,
       1,
       web3.eth.abi.encodeParameter("uint256", blockNumber),
-      {from: myAccount, gasPrice: toBN("0")}
+      { from: myAccount, gasPrice: toBN("0") }
     );
 
     const voteElements = await addVote(
@@ -204,14 +208,14 @@ contract("LAOLAND - Offchain Voting Module", async (accounts) => {
       0,
       r1.voteResultTree.getHexRoot(),
       result1,
-      {from: myAccount, gasPrice: toBN("0")}
+      { from: myAccount, gasPrice: toBN("0") }
     );
     await voting.submitVoteResult(
       dao.address,
       1,
       r2.voteResultTree.getHexRoot(),
       result2,
-      {from: myAccount, gasPrice: toBN("0")}
+      { from: myAccount, gasPrice: toBN("0") }
     );
     await advanceTime(10000);
     await onboarding.processProposal(dao.address, 0, {
@@ -243,7 +247,7 @@ contract("LAOLAND - Offchain Voting Module", async (accounts) => {
       dao.address,
       proposalId,
       web3.eth.abi.encodeParameter("uint256", blockNumber),
-      {from: myAccount, gasPrice: toBN("0")}
+      { from: myAccount, gasPrice: toBN("0") }
     );
     let ve = await addVote([], blockNumber, dao, proposalId, myAccount, true);
     ve = await addVote(ve, blockNumber, dao, proposalId, otherAccount, true);
@@ -259,7 +263,7 @@ contract("LAOLAND - Offchain Voting Module", async (accounts) => {
       proposalId,
       voteResultTree2.getHexRoot(),
       result3,
-      {from: myAccount, gasPrice: toBN("0")}
+      { from: myAccount, gasPrice: toBN("0") }
     );
 
     const nodePrevious = toStepNode(votes2[0], voteResultTree2);

--- a/utils/DaoFactory.js
+++ b/utils/DaoFactory.js
@@ -103,6 +103,7 @@ async function addDefaultAdapters(
         UPDATE_DELEGATE_KEY, REGISTER_NEW_TOKEN, REGISTER_NEW_INTERNAL_TOKEN, ADD_TO_BALANCE,SUB_FROM_BALANCE, INTERNAL_TRANSFER
      */
 
+
   await daoFactory.addAdapters(dao.address, [
     entry("voting", voting, {}),
     entry("configuration", configuration, {
@@ -181,25 +182,23 @@ async function createDao(
   gracePeriod = 1,
   tokenAddr = ETH_TOKEN
 ) {
-  if (identityDao == null) {
-    let lib = await FlagHelperLib.new();
-    await DaoRegistry.link("FlagHelper", lib.address);
+  let lib = await FlagHelperLib.new();
+  await DaoRegistry.link("FlagHelper", lib.address);
 
-    identityDao = await DaoRegistry.new({
-      from: senderAccount,
-      gasPrice: toBN("0"),
-    });
-    let receipt = await web3.eth.getTransactionReceipt(
-      identityDao.transactionHash
-    );
-    console.log(
-      "gas used to deploy the identity dao:",
-      receipt && receipt.gasUsed
-    );
-    // Call the initialize to ensure we add the first member of the DAO to initialize it
-  }
+  identityDao = await DaoRegistry.new({
+    from: senderAccount,
+    gasPrice: toBN("0"),
+  });
+  let receipt = await web3.eth.getTransactionReceipt(
+    identityDao.transactionHash
+  );
+  console.log(
+    "gas used to deploy the identity dao:",
+    receipt && receipt.gasUsed
+  );
+  // Call the initialize to ensure we add the first member of the DAO to initialize it
 
-  let dao = await cloneDao(identityDao.address, senderAccount);
+  const dao = await cloneDao(identityDao.address, senderAccount);
 
   await addDefaultAdapters(
     dao,


### PR DESCRIPTION
Closes #94

This PR adds the CloneFactory.sol contract that allows to clone a contract based on the identity/library address. We use that to clone the DAORegistry.sol contract, so we can create new DAOs and save gas.

Example:
- Gas used to **deploy** the identity dao: 4634822
- Gas used to **clone** the identity dao: 284732