### PR TITLE
Review: Ragequit

### DIFF
--- a/contracts/adapters/Ragequit.sol
+++ b/contracts/adapters/Ragequit.sol
@@ -77,7 +77,7 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
             "insufficient loot"
         );
 
-        _prepareRagequit(dao, memberAddr, sharesToBurn, lootToBurn, tokens);
+        _prepareRagequit(dao, memberAddr, sharesToBurn, lootToBurn, tokens, bank);
     }
 
     /**
@@ -94,10 +94,9 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
         address memberAddr,
         uint256 sharesToBurn,
         uint256 lootToBurn,
-        address[] memory tokens
+        address[] memory tokens,
+        BankExtension bank
     ) internal {
-        // burn shares and loot
-        BankExtension bank = BankExtension(dao.getExtensionAddress(BANK));
         ragequit.blockNumber = block.number;
         //TODO: make this the sum of all the internal tokens
         uint256 initialTotalSharesAndLoot =
@@ -114,7 +113,6 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
     /**
     * @notice Subtracts from the bank's account the proportional shares and/or loot, 
     * @notice and transfers the funds to the member's internal account based on the provided tokens.
-    * @dev ...
     * @param dao The dao address that the member is part of.
     * @param memberAddr The member address that want to burn the shares and/or loot.
     * @param sharesToBurn The amount of shares of the member that must be converted into funds.

--- a/contracts/adapters/Ragequit.sol
+++ b/contracts/adapters/Ragequit.sol
@@ -39,7 +39,7 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
         address memberAddr, 
         uint256 burnedShares, 
         uint256 burnedLoot, 
-        uint256 initialTotalSharesAndLoot)
+        uint256 initialTotalSharesAndLoot);
 
     /**
      * default fallback function to prevent from sending ether to the contract.
@@ -132,7 +132,7 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
     ) internal {
         //Update internal Guild and Member balances
         uint256 sharesAndLootBurnt = sharesToBurn + lootToBurn;
-        for (uint256 i = currentIndex; i < tokens.length; i++) {
+        for (uint256 i = 0; i < tokens.length; i++) {
             address token = tokens[i];
             require(dao.isAllowedToken(token), "token not allowed at " + i);
             // Calculates the fair amount of funds to ragequit based on the token, shares and loot
@@ -156,6 +156,6 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
             }
         }
 
-        emit MemberRagequit(memberAddr, sharesToBurn, lootToBurn,  initialTotalSharesAndLoot)
+        emit MemberRagequit(memberAddr, sharesToBurn, lootToBurn,  initialTotalSharesAndLoot);
     }
 }

--- a/contracts/adapters/Ragequit.sol
+++ b/contracts/adapters/Ragequit.sol
@@ -131,10 +131,10 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
         BankExtension bank
     ) internal {
         //Update internal Guild and Member balances
-        uint256 sharesAndLootBurnt = sharesToBurn + lootToBurn;
+        uint256 sharesAndLootToBurn = sharesToBurn + lootToBurn;
         for (uint256 i = 0; i < tokens.length; i++) {
             address token = tokens[i];
-            require(dao.isAllowedToken(token), "token not allowed at " + i);
+            require(bank.isTokenAllowed(token), "token not allowed at " + i);
             // Calculates the fair amount of funds to ragequit based on the token, shares and loot
             uint256 amountToRagequit =
                 FairShareHelper.calc(

--- a/contracts/adapters/Ragequit.sol
+++ b/contracts/adapters/Ragequit.sol
@@ -53,9 +53,10 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
     }
 
     /**
-     * @notice Allows only members to opt out of the DAO by burning the proportional amount of shares/loot of the member. 
-     * @dev the member might not be part of the DAO anymore once all one shares/loot are burned.
-     * @dev if the member provides an invalid/not allowed token, the entire processed is reverted. 
+     * @notice Allows a member or advisor of the DAO to opt out by burning the proportional amount of shares/loot of the member. 
+     * @notice Anyone is allowed to call this function, but only members and advisor that have shares are able to execute the entire ragequit process.
+     * @dev The member becomes an inative member of the DAO once all the shares/loot are burned.
+     * @dev If the member provides an invalid/not allowed token, the entire processed is reverted. 
      * @param dao The dao address that the member is part of.
      * @param sharesToBurn The amount of shares of the member that must be converted into funds.
      * @param lootToBurn The amount of loot of the member that must be converted into funds.
@@ -66,7 +67,7 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
         uint256 sharesToBurn,
         uint256 lootToBurn,
         address[] memory tokens
-    ) external override onlyMember(dao) {
+    ) external override {
         // Gets the delegated address, otherwise returns the sender address.
         address memberAddr = dao.getAddressIfDelegated(msg.sender);
         // Instantiates the Bank extension to handle the internal balance checks and transfers.

--- a/contracts/adapters/Ragequit.sol
+++ b/contracts/adapters/Ragequit.sol
@@ -75,12 +75,11 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
             "insufficient loot"
         );
 
-        _prepareRagequit(dao, memberAddr, sharesToBurn, lootToBurn, tokens, bank);
+        _prepareRagequit(memberAddr, sharesToBurn, lootToBurn, tokens, bank);
     }
 
     /**
     * @notice Subtracts from the internal member's account the proportional shares and/or loot.
-    * @param dao The dao address that the member is part of.
     * @param memberAddr The member address that want to burn the shares and/or loot.
     * @param sharesToBurn The amount of shares of the member that must be converted into funds.
     * @param lootToBurn The amount of loot of the member that must be converted into funds.
@@ -88,7 +87,6 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
     * @param bank The bank extension.
     */
     function _prepareRagequit(
-        DaoRegistry dao,
         address memberAddr,
         uint256 sharesToBurn,
         uint256 lootToBurn,
@@ -107,13 +105,12 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
         bank.subtractFromBalance(memberAddr, SHARES, sharesToBurn);
         bank.subtractFromBalance(memberAddr, LOOT, lootToBurn);
 
-        _burnShares(dao, memberAddr, sharesToBurn, lootToBurn, initialTotalSharesAndLoot, tokens, bank);
+        _burnShares(memberAddr, sharesToBurn, lootToBurn, initialTotalSharesAndLoot, tokens, bank);
     }
 
     /**
     * @notice Subtracts from the bank's account the proportional shares and/or loot, 
     * @notice and transfers the funds to the member's internal account based on the provided tokens.
-    * @param dao The dao address that the member is part of.
     * @param memberAddr The member address that want to burn the shares and/or loot.
     * @param sharesToBurn The amount of shares of the member that must be converted into funds.
     * @param lootToBurn The amount of loot of the member that must be converted into funds.
@@ -122,7 +119,6 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
     * @param bank The bank extension.
     */
     function _burnShares(
-        DaoRegistry dao,
         address memberAddr,
         uint256 sharesToBurn,
         uint256 lootToBurn,

--- a/contracts/adapters/Ragequit.sol
+++ b/contracts/adapters/Ragequit.sol
@@ -134,7 +134,7 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
         uint256 sharesAndLootToBurn = sharesToBurn + lootToBurn;
         for (uint256 i = 0; i < tokens.length; i++) {
             address token = tokens[i];
-            require(bank.isTokenAllowed(token), "token not allowed at " + i);
+            require(bank.isTokenAllowed(token), "token not allowed");
             // Calculates the fair amount of funds to ragequit based on the token, shares and loot
             uint256 amountToRagequit =
                 FairShareHelper.calc(

--- a/contracts/adapters/Ragequit.sol
+++ b/contracts/adapters/Ragequit.sol
@@ -42,7 +42,7 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
         uint256 initialTotalSharesAndLoot)
 
     /**
-     * @notice default fallback function to prevent from sending ether to the contract.
+     * default fallback function to prevent from sending ether to the contract.
      */
     receive() external payable {
         revert("fallback revert");
@@ -51,7 +51,7 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
     /**
      * @notice Allows only members to opt out of the DAO by burning the proportional amount of shares/loot of the member. 
      * @dev the member might not be part of the DAO anymore once all one shares/loot are burned.
-     * @dev if the member provides an invalida/not allowed token, the entire processed is reverted. 
+     * @dev if the member provides an invalid/not allowed token, the entire processed is reverted. 
      * @param dao The dao address that the member is part of.
      * @param sharesToBurn The amount of shares of the member that must be converted into funds.
      * @param lootToBurn The amount of loot of the member that must be converted into funds.

--- a/contracts/adapters/Ragequit.sol
+++ b/contracts/adapters/Ragequit.sol
@@ -63,7 +63,7 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
         uint256 lootToBurn,
         address[] memory tokens
     ) external override onlyMember(dao) {
-        address memberAddr = msg.sender;
+        address memberAddr = dao.getAddressIfDelegated(msg.sender);
         BankExtension bank = BankExtension(dao.getExtensionAddress(BANK));
         //Check if member has enough shares and loot to burn
         require(

--- a/contracts/adapters/Ragequit.sol
+++ b/contracts/adapters/Ragequit.sol
@@ -34,16 +34,15 @@ SOFTWARE.
  */
 
 contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
-
-
     /**
-     * @notice Event emitted when a member of the DAO executes a ragequit with all or parts of one shares/loot. 
+     * @notice Event emitted when a member of the DAO executes a ragequit with all or parts of one shares/loot.
      */
     event MemberRagequit(
-        address memberAddr, 
-        uint256 burnedShares, 
-        uint256 burnedLoot, 
-        uint256 initialTotalSharesAndLoot);
+        address memberAddr,
+        uint256 burnedShares,
+        uint256 burnedLoot,
+        uint256 initialTotalSharesAndLoot
+    );
 
     /**
      * default fallback function to prevent from sending ether to the contract.
@@ -53,10 +52,10 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
     }
 
     /**
-     * @notice Allows a member or advisor of the DAO to opt out by burning the proportional amount of shares/loot of the member. 
+     * @notice Allows a member or advisor of the DAO to opt out by burning the proportional amount of shares/loot of the member.
      * @notice Anyone is allowed to call this function, but only members and advisor that have shares are able to execute the entire ragequit process.
      * @dev The member becomes an inative member of the DAO once all the shares/loot are burned.
-     * @dev If the member provides an invalid/not allowed token, the entire processed is reverted. 
+     * @dev If the member provides an invalid/not allowed token, the entire processed is reverted.
      * @param dao The dao address that the member is part of.
      * @param sharesToBurn The amount of shares of the member that must be converted into funds.
      * @param lootToBurn The amount of loot of the member that must be converted into funds.
@@ -88,13 +87,13 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
     }
 
     /**
-    * @notice Subtracts from the internal member's account the proportional shares and/or loot.
-    * @param memberAddr The member address that want to burn the shares and/or loot.
-    * @param sharesToBurn The amount of shares of the member that must be converted into funds.
-    * @param lootToBurn The amount of loot of the member that must be converted into funds.
-    * @param tokens The array of tokens that the funds should be sent to.
-    * @param bank The bank extension.
-    */
+     * @notice Subtracts from the internal member's account the proportional shares and/or loot.
+     * @param memberAddr The member address that want to burn the shares and/or loot.
+     * @param sharesToBurn The amount of shares of the member that must be converted into funds.
+     * @param lootToBurn The amount of loot of the member that must be converted into funds.
+     * @param tokens The array of tokens that the funds should be sent to.
+     * @param bank The bank extension.
+     */
     function _prepareRagequit(
         address memberAddr,
         uint256 sharesToBurn,
@@ -107,8 +106,8 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
         // but locked loot can not be burned.
         uint256 initialTotalSharesAndLoot =
             bank.balanceOf(TOTAL, SHARES) +
-            bank.balanceOf(TOTAL, LOOT) +
-            bank.balanceOf(TOTAL, LOCKED_LOOT);
+                bank.balanceOf(TOTAL, LOOT) +
+                bank.balanceOf(TOTAL, LOCKED_LOOT);
 
         // Burns / subtracts from member's balance the number of shares to burn.
         bank.subtractFromBalance(memberAddr, SHARES, sharesToBurn);
@@ -116,19 +115,26 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
         bank.subtractFromBalance(memberAddr, LOOT, lootToBurn);
 
         // Completes the ragequit process by updating the GUILD internal balance based on each provided token.
-        _burnShares(memberAddr, sharesToBurn, lootToBurn, initialTotalSharesAndLoot, tokens, bank);
+        _burnShares(
+            memberAddr,
+            sharesToBurn,
+            lootToBurn,
+            initialTotalSharesAndLoot,
+            tokens,
+            bank
+        );
     }
 
     /**
-    * @notice Subtracts from the bank's account the proportional shares and/or loot, 
-    * @notice and transfers the funds to the member's internal account based on the provided tokens.
-    * @param memberAddr The member address that want to burn the shares and/or loot.
-    * @param sharesToBurn The amount of shares of the member that must be converted into funds.
-    * @param lootToBurn The amount of loot of the member that must be converted into funds.
-    * @param initialTotalSharesAndLoot The sum of shares and loot before internal transfers.
-    * @param tokens The array of tokens that the funds should be sent to.
-    * @param bank The bank extension.
-    */
+     * @notice Subtracts from the bank's account the proportional shares and/or loot,
+     * @notice and transfers the funds to the member's internal account based on the provided tokens.
+     * @param memberAddr The member address that want to burn the shares and/or loot.
+     * @param sharesToBurn The amount of shares of the member that must be converted into funds.
+     * @param lootToBurn The amount of loot of the member that must be converted into funds.
+     * @param initialTotalSharesAndLoot The sum of shares and loot before internal transfers.
+     * @param tokens The array of tokens that the funds should be sent to.
+     * @param bank The bank extension.
+     */
     function _burnShares(
         address memberAddr,
         uint256 sharesToBurn,
@@ -141,7 +147,7 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
         uint256 sharesAndLootToBurn = sharesToBurn + lootToBurn;
 
         // Transfers the funds from the internal Guild account to the internal member's account based on each token provided by the member.
-        // The provided token must be supported/allowed by the Guild Bank, otherwise it reverts the entire transaction. 
+        // The provided token must be supported/allowed by the Guild Bank, otherwise it reverts the entire transaction.
         for (uint256 i = 0; i < tokens.length; i++) {
             address token = tokens[i];
             // Checks if the token is supported by the Guild Bank.
@@ -154,7 +160,7 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
                     sharesAndLootToBurn,
                     initialTotalSharesAndLoot
                 );
-            
+
             // Ony execute the internal transfer if the user has enough funds to receive.
             if (amountToRagequit > 0) {
                 // gas optimization to allow a higher maximum token limit
@@ -171,6 +177,11 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
         }
 
         // Once the shares and loot were burned, and the transfers completed, emit an event to indicate a successfull operation.
-        emit MemberRagequit(memberAddr, sharesToBurn, lootToBurn,  initialTotalSharesAndLoot);
+        emit MemberRagequit(
+            memberAddr,
+            sharesToBurn,
+            lootToBurn,
+            initialTotalSharesAndLoot
+        );
     }
 }

--- a/contracts/adapters/interfaces/IRagequit.sol
+++ b/contracts/adapters/interfaces/IRagequit.sol
@@ -29,15 +29,10 @@ SOFTWARE.
  */
 
 interface IRagequit {
-    function burnShares(
-        DaoRegistry dao,
-        address memberAddr,
-        uint256 toIndex
-    ) external;
-
-    function startRagequit(
+    function ragequit(
         DaoRegistry dao,
         uint256 sharesToBurn,
-        uint256 lootToBurn
+        uint256 lootToBurn,
+        address[] memory tokens
     ) external;
 }

--- a/docs/adapters/Ragequit.md
+++ b/docs/adapters/Ragequit.md
@@ -2,7 +2,7 @@
 
 Ragequit is the process in which a member of the DAO decides to opt out of the DAO for any given reason.
 
-This implementation of ragequit adapter does not cover the case in which the member is put in jail before updating the internal balance - as it happens in Moloch V2 to disincentivize the behaviour in which members vote Yes on proposals that are essentially bad for the future of the DAO, and right after that ragequit with their funds.
+This implementation of ragequit adapter does not cover the case in which the member is put in jail before updating the internal balance - as it happens in Moloch V2 to disincentivize the behaviour in which members vote Yes on proposals that are essentially bad for the future of the DAO, and right after that they quit with their funds.
 
 It also does not check if the member has voted Yes on a proposal that is not processed yet, and does not keep track of the latest proposal that was voted Yes on.
 

--- a/docs/adapters/Ragequit.md
+++ b/docs/adapters/Ragequit.md
@@ -60,9 +60,10 @@ There are no state tracking for this adapter.
 
 ```solidity
     /**
-     * @notice Allows only members to opt out of the DAO by burning the proportional amount of shares/loot of the member.
-     * @dev the member might not be part of the DAO anymore once all one shares/loot are burned.
-     * @dev if the member provides an invalid/not allowed token, the entire processed is reverted.
+     * @notice Allows a member or advisor of the DAO to opt out by burning the proportional amount of shares/loot of the member.
+     * @notice Anyone is allowed to call this function, but only members and advisor that have shares are able to execute the entire ragequit process.
+     * @dev The member becomes an inative member of the DAO once all the shares/loot are burned.
+     * @dev If the member provides an invalid/not allowed token, the entire processed is reverted.
      * @param dao The dao address that the member is part of.
      * @param sharesToBurn The amount of shares of the member that must be converted into funds.
      * @param lootToBurn The amount of loot of the member that must be converted into funds.
@@ -73,7 +74,7 @@ There are no state tracking for this adapter.
         uint256 sharesToBurn,
         uint256 lootToBurn,
         address[] memory tokens
-    ) external override onlyMember(dao)
+    ) external
 ```
 
 ### function \_prepareRagequit

--- a/docs/adapters/Ragequit.md
+++ b/docs/adapters/Ragequit.md
@@ -1,0 +1,124 @@
+## Adapter description and scope
+
+Ragequit is the process in which a member of the DAO decides to opt out of the DAO for any given reason.
+
+This implementation of ragequit adapter does not cover the case in which the member is put in jail before updating the internal balance - as it happens in Moloch V2 to disincentivize the behaviour in which members vote Yes on proposals that are essentially bad for the future of the DAO, and right after that ragequit with their funds.
+
+It also does not check if the member has voted Yes on a proposal that is not processed yet, and does not keep track of the latest proposal that was voted Yes on.
+
+The main goal is to give the members the freedom to choose when it is the best time to withdraw their funds without any additional preconditions, except for the fact that they need have enough shares to be converted to funds, and do not need to convert all their shares/loot at once.
+
+## Adapter workflow
+
+In order to opt out of the DAO, the member needs to indicate the amount of shares and/or loots that one have decided to burn (to convert back into a token value). Only members are allowed to opt out.
+
+The proportional shares and/or loots are burned when the member provides the tokens in which one expects to receive the funds. The funds are deducted from the internal DAO bank balance, and added to the member's internal balance.
+
+If the member provides at least one invalid token, e.g: a token that is not supported/allowed by the DAO, the entire ragequit process is canceled/reverted. In addition to that, if the member provides a list of tokens that may cause issues due to the block size limit, it is expected that the transaction does not complete and return a failure.
+
+Once the process ragequit process is completed, the funds are deducted from the bank, and added to the member's internal balance, an event called `MemberRagequit` is emitted.
+
+## Adapter configuration
+
+Tokens that are provided by the member have to be allowed/supported by the DAO.
+
+The member needs to have enough shares and/or loot in order to convert it to funds.
+
+## Adapter state
+
+There are no state tracking for this adapter.
+
+## Dependencies and interactions (internal / external)
+
+- BankExtension
+
+  - to check the member's balance
+  - to subtract the member's balance.
+  - to transfer the funds from the DAO account to the member's account taking into consideration the provided tokens.
+
+- DaoRegistry
+
+  - to check if the message sender is actually a member of the DAO.
+  - to check if the provided token is supported/allowed by the DAO.
+
+- FairShareHelper
+
+  - to calculate the amount of funds to be returned to the member based on the provided numbers of shares and/or loot.
+
+## Functions description and assumptions / checks
+
+### receive() external payable
+
+```solidity
+    /**
+     * @notice default fallback function to prevent from sending ether to the contract.
+     */
+    receive() external payable
+```
+
+### function ragequit
+
+```solidity
+    /**
+     * @notice Allows only members to opt out of the DAO by burning the proportional amount of shares/loot of the member.
+     * @dev the member might not be part of the DAO anymore once all one shares/loot are burned.
+     * @dev if the member provides an invalida/not allowed token, the entire processed is reverted.
+     * @param dao The dao address that the member is part of.
+     * @param sharesToBurn The amount of shares of the member that must be converted into funds.
+     * @param lootToBurn The amount of loot of the member that must be converted into funds.
+     * @param tokens The array of tokens that the funds should be sent to.
+     */
+    function ragequit(
+        DaoRegistry dao,
+        uint256 sharesToBurn,
+        uint256 lootToBurn,
+        address[] memory tokens
+    ) external override onlyMember(dao)
+```
+
+### function \_prepareRagequit
+
+```solidity
+/**
+    * @notice Subtracts from the internal member's account the proportional shares and/or loot.
+    * @dev ...
+    * @param dao The dao address that the member is part of.
+    * @param memberAddr The member address that want to burn the shares and/or loot.
+    * @param sharesToBurn The amount of shares of the member that must be converted into funds.
+    * @param lootToBurn The amount of loot of the member that must be converted into funds.
+    * @param tokens The array of tokens that the funds should be sent to.
+    */
+    function _prepareRagequit(
+        DaoRegistry dao,
+        address memberAddr,
+        uint256 sharesToBurn,
+        uint256 lootToBurn,
+        address[] memory tokens
+    ) internal
+```
+
+### function \_burnShares
+
+```solidity
+/**
+    * @notice Subtracts from the bank's account the proportional shares and/or loot,
+    * @notice and transfers the funds to the member's internal account based on the provided tokens.
+    * @dev ...
+    * @param dao The dao address that the member is part of.
+    * @param memberAddr The member address that want to burn the shares and/or loot.
+    * @param sharesToBurn The amount of shares of the member that must be converted into funds.
+    * @param lootToBurn The amount of loot of the member that must be converted into funds.
+    * @param initialTotalSharesAndLoot .
+    * @param tokens The array of tokens that the funds should be sent to.
+    */
+    function _burnShares(
+        DaoRegistry dao,
+        address memberAddr,
+        uint256 sharesToBurn,
+        uint256 lootToBurn,
+        uint256 initialTotalSharesAndLoot,
+        address[] memory tokens
+    ) internal
+```
+
+## Events

--- a/docs/adapters/Ragequit.md
+++ b/docs/adapters/Ragequit.md
@@ -10,7 +10,7 @@ The main goal is to give the members the freedom to choose when it is the best t
 
 ## Adapter workflow
 
-In order to opt out of the DAO, the member needs to indicate the amount of shares and/or loots that one have decided to burn (to convert back into a token value). Only members are allowed to opt out.
+In order to opt out of the DAO, the member needs to indicate the amount of shares and/or loots that one have decided to burn (to convert back into a token value).
 
 The proportional shares and/or loots are burned when the member provides the tokens in which one expects to receive the funds. The funds are deducted from the internal DAO bank balance, and added to the member's internal balance.
 
@@ -35,10 +35,6 @@ There are no state tracking for this adapter.
   - to check the member's balance
   - to subtract the member's balance.
   - to transfer the funds from the DAO account to the member's account taking into consideration the provided tokens.
-
-- DaoRegistry
-
-  - to check if the message sender is actually a member of the DAO.
   - to check if the provided token is supported/allowed by the DAO.
 
 - FairShareHelper

--- a/docs/adapters/Ragequit.md
+++ b/docs/adapters/Ragequit.md
@@ -62,7 +62,7 @@ There are no state tracking for this adapter.
     /**
      * @notice Allows only members to opt out of the DAO by burning the proportional amount of shares/loot of the member.
      * @dev the member might not be part of the DAO anymore once all one shares/loot are burned.
-     * @dev if the member provides an invalida/not allowed token, the entire processed is reverted.
+     * @dev if the member provides an invalid/not allowed token, the entire processed is reverted.
      * @param dao The dao address that the member is part of.
      * @param sharesToBurn The amount of shares of the member that must be converted into funds.
      * @param lootToBurn The amount of loot of the member that must be converted into funds.
@@ -79,46 +79,55 @@ There are no state tracking for this adapter.
 ### function \_prepareRagequit
 
 ```solidity
-/**
+    /**
     * @notice Subtracts from the internal member's account the proportional shares and/or loot.
-    * @dev ...
-    * @param dao The dao address that the member is part of.
     * @param memberAddr The member address that want to burn the shares and/or loot.
     * @param sharesToBurn The amount of shares of the member that must be converted into funds.
     * @param lootToBurn The amount of loot of the member that must be converted into funds.
     * @param tokens The array of tokens that the funds should be sent to.
+    * @param bank The bank extension.
     */
     function _prepareRagequit(
-        DaoRegistry dao,
         address memberAddr,
         uint256 sharesToBurn,
         uint256 lootToBurn,
-        address[] memory tokens
+        address[] memory tokens,
+        BankExtension bank
     ) internal
 ```
 
 ### function \_burnShares
 
 ```solidity
-/**
+    /**
     * @notice Subtracts from the bank's account the proportional shares and/or loot,
     * @notice and transfers the funds to the member's internal account based on the provided tokens.
-    * @dev ...
-    * @param dao The dao address that the member is part of.
     * @param memberAddr The member address that want to burn the shares and/or loot.
     * @param sharesToBurn The amount of shares of the member that must be converted into funds.
     * @param lootToBurn The amount of loot of the member that must be converted into funds.
-    * @param initialTotalSharesAndLoot .
+    * @param initialTotalSharesAndLoot The sum of shares and loot before internal transfers.
     * @param tokens The array of tokens that the funds should be sent to.
+    * @param bank The bank extension.
     */
     function _burnShares(
-        DaoRegistry dao,
         address memberAddr,
         uint256 sharesToBurn,
         uint256 lootToBurn,
         uint256 initialTotalSharesAndLoot,
-        address[] memory tokens
+        address[] memory tokens,
+        BankExtension bank
     ) internal
 ```
 
 ## Events
+
+```solidity
+    /**
+     * @notice Event emitted when a member of the DAO executes a ragequit with all or parts of one shares/loot.
+     */
+    event MemberRagequit(
+        address memberAddr,
+        uint256 burnedShares,
+        uint256 burnedLoot,
+        uint256 initialTotalSharesAndLoot)
+```


### PR DESCRIPTION
Updated the Ragequit adapter to solve the issues raised in the review phase and created the Ragequit.md

Main Changes:
- ragequit done in transaction, instead of two, so the member that executes a ragequit is also responsible for paying for that.
- the tokens are now passed as parameters and check if they are allowed by the Bank, if the tx fails due to the block limit, the member needs to retry with less tokens.
- it is not necessary to keep track of the ragequit states anymore because now it happens in one tx only
- locked loot is considered to calculate the fair share, but locked loot can not be burned
- the member does not go to jail anymore and once all shares are burned, the member becomes not active, hence one can not vote or sponsor anymore.
- the ragequit function is open, which means anyone is able to call it, but only members/advisors are able to actually execute the entire ragequit process (if they have enough shares to burn).