### PR TITLE
Review: Guild Kick

### DIFF
--- a/contracts/adapters/GuildKick.sol
+++ b/contracts/adapters/GuildKick.sol
@@ -234,10 +234,13 @@ contract GuildKickContract is IGuildKick, DaoConstants, MemberGuard {
             maxIndex = nbTokens;
         }
 
-        // Calculates the total shares and loot before any internal transfers.
+        // Calculates the total shares, loot and locked loot before any internal transfers
+        // it considers the locked loot to be able to calculate the fair amount to ragequit,
+        // but locked loot can not be burned.
         uint256 initialTotalSharesAndLoot =
             bank.getPriorAmount(TOTAL, SHARES, kick.blockNumber) +
-                bank.getPriorAmount(TOTAL, LOOT, kick.blockNumber);
+                bank.getPriorAmount(TOTAL, LOOT, kick.blockNumber) +
+                bank.getPriorAmount(TOTAL, LOCKED_LOOT, kick.blockNumber);
 
         // Get the member address to kick out of the DAO
         address kickedMember = kick.memberToKick;

--- a/contracts/adapters/GuildKick.sol
+++ b/contracts/adapters/GuildKick.sol
@@ -63,8 +63,8 @@ contract GuildKickContract is IGuildKick, DaoConstants, MemberGuard {
     // Keeps track of the latest ongoing kick proposal per DAO to ensure only 1 kick happens at time.
     mapping(address => GuildKickStatus) public ongoingKicks;
 
-    /*
-     * default fallback function to prevent from sending ether to the contract
+    /**
+     * @notice default fallback function to prevent from sending ether to the contract.
      */
     receive() external payable {
         revert("fallback revert");
@@ -75,7 +75,7 @@ contract GuildKickContract is IGuildKick, DaoConstants, MemberGuard {
      * @dev A member can not kick himself.     
      * @dev Only one kick per DAO can be executed at time.
      * @dev Only members that have shares can be kicked out.
-     *** @dev Proposal ids can not be reused.
+     * @dev Proposal ids can not be reused.
      * @param dao The dao address.
      * @param proposalId The guild kick proposal id.
      * @param memberToKick The member address that should be kicked out of the DAO.
@@ -93,8 +93,8 @@ contract GuildKickContract is IGuildKick, DaoConstants, MemberGuard {
         // Checks if there is an ongoing kick proposal, only one kick can be executed at time.
         require(ongoingKicks[address(dao)] != GuildKickStatus.IN_PROGRESS, "there is a kick in progress");
 
-        //TODO Checks if the proposalId already exists
-        //require(kicks[address(dao)][proposalId].status == GuildKickStatus.NOT_STARTED, "");
+        // Checks if the proposalId already exists
+        require(kicks[address(dao)][proposalId].status == GuildKickStatus.NOT_STARTED, "kick proposal id already used");
 
         // Creates a guild kick proposal.
         dao.submitProposal(proposalId);
@@ -205,7 +205,7 @@ contract GuildKickContract is IGuildKick, DaoConstants, MemberGuard {
         DaoRegistry dao,
         bytes32 proposalId,
         uint256 toIndex
-    ) external override onlyMember(dao) {//should be open?
+    ) external override onlyMember(dao) {//should be open it so the kicked member is able to call this function?
         // Checks if the kick proposal does not exist or is not completed yet
         GuildKick storage kick = kicks[address(dao)][proposalId];
         require(

--- a/contracts/adapters/Ragequit.sol
+++ b/contracts/adapters/Ragequit.sol
@@ -54,6 +54,8 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
     /**
      * @notice Allows a member or advisor of the DAO to opt out by burning the proportional amount of shares/loot of the member.
      * @notice Anyone is allowed to call this function, but only members and advisor that have shares are able to execute the entire ragequit process.
+     * @dev The sum of sharesToBurn and lootToBurn have to be greater than zero.
+     * @dev The member can not be in jail to execute a ragequit.
      * @dev The member becomes an inative member of the DAO once all the shares/loot are burned.
      * @dev If the member provides an invalid/not allowed token, the entire processed is reverted.
      * @param dao The dao address that the member is part of.

--- a/contracts/adapters/Ragequit.sol
+++ b/contracts/adapters/Ragequit.sol
@@ -111,8 +111,7 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
         // it considers the locked loot to be able to calculate the fair amount to ragequit,
         // but locked loot can not be burned.
         uint256 initialTotalSharesAndLoot =
-            bank.balanceOf(TOTAL, SHARES) +
-                bank.balanceOf(TOTAL, LOOT);
+            bank.balanceOf(TOTAL, SHARES) + bank.balanceOf(TOTAL, LOOT);
 
         // Burns / subtracts from member's balance the number of shares to burn.
         bank.subtractFromBalance(memberAddr, SHARES, sharesToBurn);

--- a/contracts/adapters/Ragequit.sol
+++ b/contracts/adapters/Ragequit.sol
@@ -70,8 +70,11 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
         // Checks if the are enough shares and/or loot to burn
         require(sharesToBurn + lootToBurn > 0, "insufficient shares/loot");
 
-        // Checks if the member is not in jail due to a Guild Kick
-        // isActiveMember?
+        // Checks if the member is not in jail
+        require(
+            !dao.getMemberFlag(msg.sender, DaoRegistry.MemberFlag.JAILED),
+            "jailed member can not ragequit"
+        );
 
         // Gets the delegated address, otherwise returns the sender address.
         address memberAddr = dao.getAddressIfDelegated(msg.sender);

--- a/contracts/adapters/Ragequit.sol
+++ b/contracts/adapters/Ragequit.sol
@@ -116,7 +116,9 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
         // it considers the locked loot to be able to calculate the fair amount to ragequit,
         // but locked loot can not be burned.
         uint256 initialTotalSharesAndLoot =
-            bank.balanceOf(TOTAL, SHARES) + bank.balanceOf(TOTAL, LOOT);
+            bank.balanceOf(TOTAL, SHARES) +
+                bank.balanceOf(TOTAL, LOOT) +
+                bank.balanceOf(TOTAL, LOCKED_LOOT);
 
         // Burns / subtracts from member's balance the number of shares to burn.
         bank.subtractFromBalance(memberAddr, SHARES, sharesToBurn);

--- a/contracts/adapters/Ragequit.sol
+++ b/contracts/adapters/Ragequit.sol
@@ -67,6 +67,12 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
         uint256 lootToBurn,
         address[] memory tokens
     ) external override {
+        // Checks if the are enough shares and/or loot to burn
+        require(sharesToBurn + lootToBurn > 0, "insufficient shares/loot");
+
+        // Checks if the member is not in jail due to a Guild Kick
+        // isActiveMember?
+
         // Gets the delegated address, otherwise returns the sender address.
         address memberAddr = dao.getAddressIfDelegated(msg.sender);
         // Instantiates the Bank extension to handle the internal balance checks and transfers.
@@ -106,8 +112,7 @@ contract RagequitContract is IRagequit, DaoConstants, MemberGuard {
         // but locked loot can not be burned.
         uint256 initialTotalSharesAndLoot =
             bank.balanceOf(TOTAL, SHARES) +
-                bank.balanceOf(TOTAL, LOOT) +
-                bank.balanceOf(TOTAL, LOCKED_LOOT);
+                bank.balanceOf(TOTAL, LOOT);
 
         // Burns / subtracts from member's balance the number of shares to burn.
         bank.subtractFromBalance(memberAddr, SHARES, sharesToBurn);

--- a/contracts/adapters/interfaces/IGuildKick.sol
+++ b/contracts/adapters/interfaces/IGuildKick.sol
@@ -43,4 +43,5 @@ interface IGuildKick {
         bytes32 proposalId,
         uint256 toIndex
     ) external;
+
 }

--- a/contracts/adapters/interfaces/IGuildKick.sol
+++ b/contracts/adapters/interfaces/IGuildKick.sol
@@ -43,5 +43,4 @@ interface IGuildKick {
         bytes32 proposalId,
         uint256 toIndex
     ) external;
-
 }

--- a/contracts/helpers/FairShareHelper.sol
+++ b/contracts/helpers/FairShareHelper.sol
@@ -40,7 +40,6 @@ library FairShareHelper {
         }
         uint256 prod = balance * shares;
         if (prod / balance == shares) {
-            // no overflow in multiplication above?
             return prod / _totalShares;
         }
         return (balance / _totalShares) * shares;

--- a/docs/adapters/GuildKick.md
+++ b/docs/adapters/GuildKick.md
@@ -57,7 +57,7 @@ The member needs to have enough shares and/or loot in order to convert it to fun
 
   - checks if the message sender is actually a member of the DAO.
   - checks if the kicked member is actually a member of the DAO.
-  - processing the kick proposal.
+  - process the kick proposal.
   - jail/unjail the kicked member
 
 - Voting

--- a/docs/adapters/GuildKick.md
+++ b/docs/adapters/GuildKick.md
@@ -2,7 +2,7 @@
 
 Guild Kick is the process in which the DAO members decide to kick a member out of the DAO for any given reason.
 
-In order to kick out a member of the DAO, the members must submit a proposal which needs to be voted on. If the proposal pass, then the member will be kicked out, and the kicked member will be able to withdraw his funds based on the number of shares and loot that the member was holding.
+In order to kick out a member of the DAO, the members must submit a proposal which needs to be voted on. If the proposal pass, then the member will be kicked out, and the kicked member will be able to withdraw his funds based on the number of shares and loot that the member was holding when the kick process was started.
 
 The main goal is to give the members the freedom to choose which individuals should really be part of the DAO.
 
@@ -11,16 +11,16 @@ The main goal is to give the members the freedom to choose which individuals sho
 The guild kick starts with the other members submitting a kick proposal (function `submitKickProposal`).
 The kick proposal indicates which member should be kicked out.
 
-A member can not kick himself, and only one kick proposal can be executed at time. In addition to that, only members are allowed to create kick proposals.
+A member can not kick himself, and only one kick proposal can be executed at time. In addition to that, only members are allowed to create kick proposals, and proposal ids can not be reused.
 
-The kick proposal gets created, open for voting, and sponsored by the message sender. The adapter tracks all the kicks that have been executed already by the DAO, and also tracks the current kick that is still in progress - this is done to ensure the kicks are executed sequentially.
+The kick proposal gets created, open for voting, and sponsored by the message sender. The adapter tracks all the kicks that have been executed already by the DAO, and also tracks the current kick that is in progress - this is done to ensure the kicks are executed sequentially per DAO.
 
-Once the proposal to kick out the member has passed, the other members have to start the actual guild kick process (function `guildKick`). In this process the kicked member has its shares converted to loot, which removes his voting power, and after that his put in jail, so he can not perform any other actions in the DAO anymore. After that the kick proposal is completed, but the kicked member still does not have received his funds yet.
+Once the kick proposal has passed, the other members have to start the actual guild kick process (function `guildKick`). In this process the kicked member has its shares converted to loot, which removes his voting power, and after that the kicked member put in jail, so he can not perform any other actions in the DAO. After that, the kick proposal is completed, but the kicked member still does not have received his funds yet.
 
-While the kicked member is in jail, an active member of the DAO, or the actual kicked member can trigger the internal transfer process to grant the funds to the kicked member (function `rageKick`) (maybe we can make this function open, otherwise the kicked member wont be able to call it, because he is in jail).
+While the kicked member is in jail, an active member of the DAO needs trigger the internal transfer process to release the funds of the kicked member, to do that the member just need to execute the rage kick process (function `rageKick`).
 
 The rage kick process is only alternative for a kicked member to receive his funds, it checks the historical guild balance (when the guild kick proposal has been created) to calculate the fair amount of funds to return to the kicked member.
-It is important to mention that this process my take multiple steps, because it relies on the number of tokens available in the bank. The funds are internally transfered from the Guild bank to the kicked member's account, so the member can withdraw the funds later on. At the end of the process, after all the transfers were completed with success for all available tokens, the kicked member's loot are burned and the member is removed from jail - because he is not an active member anymore.
+It is important to mention that this process might be executed in multiple steps, because it relies on the number of tokens available in the bank. The funds are internally transfered from the Guild bank to the kicked member's account, so the member can withdraw the funds later on. At the end of the process, after all the transfers were completed with success for all available tokens, the kicked member's loot are burned and the member is removed from jail - because he is not an active member anymore. Only loot are burned because the shares were already converted to loot during the `guildKick` process.
 
 ## Adapter configuration
 
@@ -30,24 +30,44 @@ The member needs to have enough shares and/or loot in order to convert it to fun
 
 ## Adapter state
 
-There are no state tracking for this adapter.
+- `GuildKickStatus`: The kick status (Not Started, In Progress, Done).
+- `GuildKick`: State of the guild kick proposal
+  - `memberToKick`: The address of the member to kick out of the DAO.
+  - `status`: The kick status.
+  - `sharesToBurn`: The number of shares of the member that should be burned.
+  - `lootToBurn`: The number of loot of the member that should be burned.
+  - `data`: Additional information related to the kick proposal.
+  - `currentIndex`: Current iteration index to control the cached for-loop.
+  - `blockNumber`: The block number in which the guild kick proposal has been created.
+- `kicks`: Keeps track of all the kicks executed per DAO.
+- `ongoingKicks`: Keeps track of the latest ongoing kick proposal per DAO to ensure only 1 kick happens at time.
 
 ## Dependencies and interactions (internal / external)
 
 - BankExtension
 
-  - to check the member's balance
-  - to subtract the member's balance.
-  - to transfer the funds from the DAO account to the member's account taking into consideration the provided tokens.
+  - checks the kicked member's balance
+  - subtracts the kicked member's shares.
+  - adds the burned shares to the kicked member's loot account.
+  - transfers the funds from the DAO account to the kicked member's account.
+  - gets the available tokens.
+  - gets the historical balance of the guild account.
 
 - DaoRegistry
 
-  - to check if the message sender is actually a member of the DAO.
-  - to check if the provided token is supported/allowed by the DAO.
+  - checks if the message sender is actually a member of the DAO.
+  - checks if the kicked member is actually a member of the DAO.
+  - processing the kick proposal.
+  - jail/unjail the kicked member
+
+- Voting
+
+  - starts a new voting for the kick proposal.
+  - checks the voting results.
 
 - FairShareHelper
 
-  - to calculate the amount of funds to be returned to the member based on the provided numbers of shares and/or loot.
+  - to calculate the amount of funds to be returned to the member based on the provided numbers of shares and/or loot, taking into account the historical balance of the GUILD and kicked member's accounts.
 
 ## Functions description and assumptions / checks
 
@@ -60,79 +80,70 @@ There are no state tracking for this adapter.
     receive() external payable
 ```
 
-### function ragequit
+### function submitKickProposal
 
 ```solidity
     /**
-     * @notice Allows a member or advisor of the DAO to opt out by burning the proportional amount of shares/loot of the member.
-     * @notice Anyone is allowed to call this function, but only members and advisor that have shares are able to execute the entire ragequit process.
-     * @dev The member becomes an inative member of the DAO once all the shares/loot are burned.
-     * @dev If the member provides an invalid/not allowed token, the entire processed is reverted.
-     * @param dao The dao address that the member is part of.
-     * @param sharesToBurn The amount of shares of the member that must be converted into funds.
-     * @param lootToBurn The amount of loot of the member that must be converted into funds.
-     * @param tokens The array of tokens that the funds should be sent to.
+     * @notice Creates a guild kick proposal, opens it for voting, and sponsors it.
+     * @dev A member can not kick himself.
+     * @dev Only one kick per DAO can be executed at time.
+     * @dev Only members that have shares can be kicked out.
+     * @dev Proposal ids can not be reused.
+     * @param dao The dao address.
+     * @param proposalId The guild kick proposal id.
+     * @param memberToKick The member address that should be kicked out of the DAO.
+     * @param data Additional information related to the kick proposal.
      */
-    function ragequit(
+    function submitKickProposal(
         DaoRegistry dao,
-        uint256 sharesToBurn,
-        uint256 lootToBurn,
-        address[] memory tokens
-    ) external
+        bytes32 proposalId,
+        address memberToKick,
+        bytes calldata data
+    ) external override onlyMember(dao)
 ```
 
-### function \_prepareRagequit
+### function guildKick
 
 ```solidity
     /**
-    * @notice Subtracts from the internal member's account the proportional shares and/or loot.
-    * @param memberAddr The member address that want to burn the shares and/or loot.
-    * @param sharesToBurn The amount of shares of the member that must be converted into funds.
-    * @param lootToBurn The amount of loot of the member that must be converted into funds.
-    * @param tokens The array of tokens that the funds should be sent to.
-    * @param bank The bank extension.
-    */
-    function _prepareRagequit(
-        address memberAddr,
-        uint256 sharesToBurn,
-        uint256 lootToBurn,
-        address[] memory tokens,
-        BankExtension bank
-    ) internal
+     * @notice Process the guild kick proposal, converts the member's shares into loot.
+     * @notice The kicked member is put in jail, so he can not perform any other action in the DAO.
+     * @dev A kick proposal must be in progress.
+     * @dev Only one kick per DAO can be executed at time.
+     * @dev Only active members can be kicked out.
+     * @dev Only proposals that passed the voting can be completed.
+     * @param dao The dao address.
+     * @param proposalId The guild kick proposal id.
+     */
+    function guildKick(DaoRegistry dao, bytes32 proposalId)
+        external
+        override
+        onlyMember(dao)
 ```
 
-### function \_burnShares
+### function rageKick
 
 ```solidity
     /**
-    * @notice Subtracts from the bank's account the proportional shares and/or loot,
-    * @notice and transfers the funds to the member's internal account based on the provided tokens.
-    * @param memberAddr The member address that want to burn the shares and/or loot.
-    * @param sharesToBurn The amount of shares of the member that must be converted into funds.
-    * @param lootToBurn The amount of loot of the member that must be converted into funds.
-    * @param initialTotalSharesAndLoot The sum of shares and loot before internal transfers.
-    * @param tokens The array of tokens that the funds should be sent to.
-    * @param bank The bank extension.
-    */
-    function _burnShares(
-        address memberAddr,
-        uint256 sharesToBurn,
-        uint256 lootToBurn,
-        uint256 initialTotalSharesAndLoot,
-        address[] memory tokens,
-        BankExtension bank
-    ) internal
+     * @notice Transfers the funds from the Guild account to the kicked member account.
+     * @notice The amount of funds is caculated using the historical balance when the proposal was created.
+     * @notice loot
+     * @notice The kicked member is put in jail, so he can not perform any other action in the DAO.
+     * @dev A kick proposal must be in progress.
+     * @dev Only one kick per DAO can be executed at time.
+     * @dev Only active members can be kicked out.
+     * @dev Only proposals that passed the voting can be completed.
+     * @param dao The dao address.
+     * @param proposalId The guild kick proposal id.
+     * @param toIndex The index to control the cached for-loop.
+     */
+    function rageKick(
+        DaoRegistry dao,
+        bytes32 proposalId,
+        uint256 toIndex
+    ) external override onlyMember(dao)
 ```
 
 ## Events
 
-```solidity
-    /**
-     * @notice Event emitted when a member of the DAO executes a ragequit with all or parts of one shares/loot.
-     */
-    event MemberRagequit(
-        address memberAddr,
-        uint256 burnedShares,
-        uint256 burnedLoot,
-        uint256 initialTotalSharesAndLoot)
-```
+None

--- a/docs/adapters/Ragequit.md
+++ b/docs/adapters/Ragequit.md
@@ -32,18 +32,19 @@ There are no state tracking for this adapter.
 
 - BankExtension
 
-  - to check the member's balance
-  - to subtract the member's balance.
-  - to transfer the funds from the DAO account to the member's account taking into consideration the provided tokens.
+  - checks the member's balance.
+  - subtracts the member's balance.
+  - transfers the funds from the DAO account to the member's account taking into consideration the provided tokens.
 
 - DaoRegistry
 
-  - to check if the message sender is actually a member of the DAO.
-  - to check if the provided token is supported/allowed by the DAO.
+  - checks if the member is not in jail before allowing the ragequit.
+  - checks if the message sender is actually a member of the DAO.
+  - checks if the provided token is supported/allowed by the DAO.
 
 - FairShareHelper
 
-  - to calculate the amount of funds to be returned to the member based on the provided numbers of shares and/or loot.
+  - calculates the amount of funds to be returned to the member based on the provided numbers of shares and/or loot.
 
 ## Functions description and assumptions / checks
 
@@ -62,6 +63,8 @@ There are no state tracking for this adapter.
     /**
      * @notice Allows a member or advisor of the DAO to opt out by burning the proportional amount of shares/loot of the member.
      * @notice Anyone is allowed to call this function, but only members and advisor that have shares are able to execute the entire ragequit process.
+     * @dev The sum of sharesToBurn and lootToBurn have to be greater than zero.
+     * @dev The member can not be in jail to execute a ragequit.
      * @dev The member becomes an inative member of the DAO once all the shares/loot are burned.
      * @dev If the member provides an invalid/not allowed token, the entire processed is reverted.
      * @param dao The dao address that the member is part of.

--- a/docs/adapters/Ragequit.md
+++ b/docs/adapters/Ragequit.md
@@ -10,13 +10,15 @@ The main goal is to give the members the freedom to choose when it is the best t
 
 ## Adapter workflow
 
-In order to opt out of the DAO, the member needs to indicate the amount of shares and/or loots that one have decided to burn (to convert back into a token value). Only members are allowed to opt out.
+In order to opt out of the DAO, the member needs to indicate the amount of shares and/or loots that one have decided to burn (to convert back into a token value).
 
 The proportional shares and/or loots are burned when the member provides the tokens in which one expects to receive the funds. The funds are deducted from the internal DAO bank balance, and added to the member's internal balance.
 
 If the member provides at least one invalid token, e.g: a token that is not supported/allowed by the DAO, the entire ragequit process is canceled/reverted. In addition to that, if the member provides a list of tokens that may cause issues due to the block size limit, it is expected that the transaction does not complete and return a failure.
 
 Once the process ragequit process is completed, the funds are deducted from the bank, and added to the member's internal balance, an event called `MemberRagequit` is emitted.
+
+It is important to mention that members that are in jail are not allowed to ragequit, and the function is open (without access modifier) because advisors should be able to ragequit - and advisor are not active members (shares > 0) because they only hold loot.
 
 ## Adapter configuration
 

--- a/test/adapters/ragequit.test.js
+++ b/test/adapters/ragequit.test.js
@@ -708,4 +708,6 @@ contract("LAOLAND - Ragequit Adapter", async (accounts) => {
       assert.equal(err.reason, "jailed member can not ragequit");
     }
   });
+
+  //TODO test fairShareHelper overflow
 });

--- a/test/adapters/ragequit.test.js
+++ b/test/adapters/ragequit.test.js
@@ -1,4 +1,4 @@
-d; // Whole-script strict mode syntax
+// Whole-script strict mode syntax
 ("use strict");
 
 /**

--- a/test/adapters/ragequit.test.js
+++ b/test/adapters/ragequit.test.js
@@ -24,34 +24,13 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
-
-async function ragequit(dao, shares, loot, member) {
-  const bankAddress = await dao.getExtensionAddress(sha3("bank"));
-  const bank = await BankExtension.at(bankAddress);
-  let ragequitAddress = await dao.getAdapterAddress(sha3("ragequit"));
-  let ragequitContract = await RagequitContract.at(ragequitAddress);
-
-  await ragequitContract.startRagequit(dao.address, toBN(shares), toBN(loot), {
-    from: member,
-    gasPrice: toBN("0"),
-  });
-
-  await ragequitContract.burnShares(dao.address, member, 2, {
-    gasPrice: toBN("0"),
-  });
-
-  //Check New Member Shares
-  let newShares = await bank.balanceOf(member, SHARES);
-  assert.equal(newShares.toString(), "0");
-  return ragequitContract;
-}
-
 const {
   sha3,
   toBN,
   fromUtf8,
   advanceTime,
   createDao,
+  getContract,
   sharePrice,
   GUILD,
   ETH_TOKEN,
@@ -61,27 +40,30 @@ const {
   OnboardingContract,
   VotingContract,
   RagequitContract,
+  GuildKickContract,
   FinancingContract,
   BankExtension,
 } = require("../../utils/DaoFactory.js");
+
 let proposalCounter = 0;
 contract("LAOLAND - Ragequit Adapter", async (accounts) => {
   const submitNewMemberProposal = async (
     onboarding,
     dao,
     newMember,
-    sharePrice
+    sharePrice,
+    token,
+    sponsor
   ) => {
-    const myAccount = accounts[1];
     const proposalId = "0x" + proposalCounter++;
     await onboarding.onboard(
       dao.address,
       proposalId,
       newMember,
-      SHARES,
+      token ? token : SHARES,
       sharePrice.mul(toBN(100)),
       {
-        from: myAccount,
+        from: sponsor ? sponsor : accounts[1],
         value: sharePrice.mul(toBN(10)),
         gasPrice: toBN("0"),
       }
@@ -105,6 +87,28 @@ contract("LAOLAND - Ragequit Adapter", async (accounts) => {
       gasPrice: toBN("0"),
     });
     await advanceTime(10000);
+  };
+
+  const guildKickProposal = async (
+    dao,
+    guildkickContract,
+    memberToKick,
+    sender,
+    proposalId = null
+  ) => {
+    const newProposalId = proposalId ? proposalId : "0x" + proposalCounter++;
+    await guildkickContract.submitKickProposal(
+      dao.address,
+      newProposalId,
+      memberToKick,
+      fromUtf8(""),
+      {
+        from: sender,
+        gasPrice: toBN("0"),
+      }
+    );
+
+    return { kickProposalId: newProposalId };
   };
 
   const ragequit = async (dao, shares, loot, member, token = ETH_TOKEN) => {
@@ -599,6 +603,109 @@ contract("LAOLAND - Ragequit Adapter", async (accounts) => {
       );
     } catch (err) {
       assert.equal(err.reason, "token not allowed");
+    }
+  });
+
+  it("should be possible to ragequit if the member is part of a guild kick proposal but the proposal is not processed yet", async () => {
+    const daoOwner = accounts[1];
+    const memberA = accounts[2];
+
+    let dao = await createDao(daoOwner);
+    const onboarding = await getContract(dao, "onboarding", OnboardingContract);
+    const voting = await getContract(dao, "voting", VotingContract);
+    const guildkickContract = await getContract(
+      dao,
+      "guildkick",
+      GuildKickContract
+    );
+
+    let proposalId = await submitNewMemberProposal(
+      onboarding,
+      dao,
+      memberA,
+      sharePrice
+    );
+
+    //Sponsor the new proposal to admit the new member, vote and process it
+    await sponsorNewMember(onboarding, dao, proposalId, daoOwner, voting);
+    await onboarding.processProposal(dao.address, proposalId, {
+      from: daoOwner,
+      gasPrice: toBN("0"),
+    });
+
+    // Check memberA shares
+    const bankAddress = await dao.getExtensionAddress(sha3("bank"));
+    const bank = await BankExtension.at(bankAddress);
+    let memberAShares = await bank.balanceOf(memberA, SHARES);
+
+    // Submit GuildKick for memberA
+    await guildKickProposal(dao, guildkickContract, memberA, daoOwner);
+
+    // MemberA ragequits before the kick proposal is processed
+    await ragequit(dao, memberAShares, 0, memberA, ETH_TOKEN);
+  });
+
+  it("should not be possible to ragequit if the member is in jail", async () => {
+    const daoOwner = accounts[1];
+    const memberA = accounts[2];
+
+    let dao = await createDao(daoOwner);
+    const onboarding = await getContract(dao, "onboarding", OnboardingContract);
+    const voting = await getContract(dao, "voting", VotingContract);
+    const guildkickContract = await getContract(
+      dao,
+      "guildkick",
+      GuildKickContract
+    );
+
+    let proposalId = await submitNewMemberProposal(
+      onboarding,
+      dao,
+      memberA,
+      sharePrice
+    );
+
+    //Sponsor the new proposal to admit the new member, vote and process it
+    await sponsorNewMember(onboarding, dao, proposalId, daoOwner, voting);
+    await onboarding.processProposal(dao.address, proposalId, {
+      from: daoOwner,
+      gasPrice: toBN("0"),
+    });
+
+    // Check memberA shares
+    const bankAddress = await dao.getExtensionAddress(sha3("bank"));
+    const bank = await BankExtension.at(bankAddress);
+    let memberAShares = await bank.balanceOf(memberA, SHARES);
+
+    // Submit GuildKick for memberA
+    let { kickProposalId } = await guildKickProposal(
+      dao,
+      guildkickContract,
+      memberA,
+      daoOwner
+    );
+
+    //Vote YES on kick proposal
+    await voting.submitVote(dao.address, kickProposalId, 1, {
+      from: daoOwner,
+      gasPrice: toBN("0"),
+    });
+    await advanceTime(10000);
+
+    // Process the guild kick proposal to put the member in jail
+    await guildkickContract.guildKick(dao.address, kickProposalId, {
+      from: daoOwner,
+      gasPrice: toBN("0"),
+    });
+
+    try {
+      // MemberA attempts to ragequit, but he is in jail due to the guild kick
+      await ragequit(dao, memberAShares, 0, memberA, ETH_TOKEN);
+      assert.fail(
+        "should not be possible to ragequit if the member is in jail"
+      );
+    } catch (err) {
+      assert.equal(err.reason, "jailed member can not ragequit");
     }
   });
 });

--- a/test/adapters/ragequit.test.js
+++ b/test/adapters/ragequit.test.js
@@ -1,5 +1,5 @@
-d// Whole-script strict mode syntax
-"use strict";
+d; // Whole-script strict mode syntax
+("use strict");
 
 /**
 MIT License

--- a/test/adapters/ragequit.test.js
+++ b/test/adapters/ragequit.test.js
@@ -1,4 +1,4 @@
-// Whole-script strict mode syntax
+d// Whole-script strict mode syntax
 "use strict";
 
 /**

--- a/utils/TestUtils.js
+++ b/utils/TestUtils.js
@@ -1,20 +1,51 @@
 // Whole-script strict mode syntax
-'use strict';
+"use strict";
 
-async function checkLastEvent(dao, testObject) {
-    let pastEvents = await dao.getPastEvents();
-    let returnValues  = pastEvents[0].returnValues;
-    
-    Object.keys(testObject).forEach(key => {
-        assert.equal(testObject[key], returnValues[key], "value mismatch for key " + key);
-    });
-}
+const { toBN, advanceTime, SHARES } = require("./DaoFactory.js");
 
-async function checkBalance(bank, address, token, expectedBalance) {
-    const balance = await bank.balanceOf(address, token);
+const checkLastEvent = async (dao, testObject) => {
+  let pastEvents = await dao.getPastEvents();
+  let returnValues = pastEvents[0].returnValues;
 
-    assert.equal(balance.toString(), expectedBalance.toString());
-}
+  Object.keys(testObject).forEach((key) => {
+    assert.equal(
+      testObject[key],
+      returnValues[key],
+      "value mismatch for key " + key
+    );
+  });
+};
 
+const checkBalance = async (bank, address, token, expectedBalance) => {
+  const balance = await bank.balanceOf(address, token);
 
-module.exports = {checkLastEvent, checkBalance};
+  assert.equal(balance.toString(), expectedBalance.toString());
+};
+
+const submitNewMemberProposal = async (
+  onboarding,
+  dao,
+  newMember,
+  sharePrice,
+  sender,
+  proposalId
+) => {
+  await onboarding.onboard(
+    dao.address,
+    proposalId,
+    newMember,
+    SHARES,
+    sharePrice.mul(toBN(100)),
+    {
+      from: sender,
+      value: sharePrice.mul(toBN(10)),
+      gasPrice: toBN("0"),
+    }
+  );
+  return proposalId;
+};
+
+module.exports = {
+  checkLastEvent,
+  checkBalance,
+};


### PR DESCRIPTION
Code review, docs and fixes for Guild Kick adapter:
- A member can not kick himself.
- Non-active members can not be kicked out, or start a kick process.
- Shares are converted into Loot, and Loot are burned once the ragekick process is completed.
- Fix to use the historical balance of the guild, and kicked member to calculate the fair amount of funds to ragequit (still need to fix the overflow issue on FairShareHelper).
- Proposal Ids can not be reused.
- The kicked member stays in jail until a DAO member starts the ragekick process to release the funds.
- Fixed the FairShare formula to take into account the Shares, Loot, and Locked Loot. We only burn Shares & Loot, and it is not allowed to burn Locked Loot from the Guild account. 
- If the member is in jail due to a kick proposal that has been processed, it not possible to execute a ragequit anymore.
- Ragequit and Rage kick are different in using old/new balance mainly because now Ragequit is done one single transaction and can use the current balance, and the RageKick is done in multiple steps, so it needs to use the historical balace. In addition to that, both are burning the shares and loot, but the main difference is that ragequit burns all at once, and ragekick first converts the shares into loot (to remove the voting power of the member), and only after the kick is processed the loot is burned.
- Added more tests