### PR TITLE
Fix dao creation

### DIFF
--- a/contracts/core/DaoFactory.sol
+++ b/contracts/core/DaoFactory.sol
@@ -63,7 +63,7 @@ contract DaoFactory is CloneFactory, DaoConstants {
         );
         DaoRegistry dao = DaoRegistry(_createClone(identityAddress));
         address daoAddr = address(dao);
-        dao.initialize(creator, msg.sender);
+        dao.initialize(creator, address(this));
 
         addresses[hashedName] = daoAddr;
         daos[daoAddr] = hashedName;

--- a/test/core/daofactory.test.js
+++ b/test/core/daofactory.test.js
@@ -39,7 +39,7 @@ contract("DaoFactory", async (accounts) => {
 
   const cloneDao = async (owner, identityAddr, name) => {
     let daoFactory = await DaoFactory.new(identityAddr);
-    await daoFactory.createDao(name, {
+    await daoFactory.createDao(name, owner, {
       from: owner,
       gasPrice: toBN("0"),
     });


### PR DESCRIPTION
It was not passing the daoFactory address to the clone registry, and was missing the creator address in the js call. 
@adridadou I was wondering if we should use msg.sender instead of using a function arg to get the creator. Wdyt?