### PR TITLE
ERC20 contract and usage updates

### DIFF
--- a/contracts/helpers/Context.sol
+++ b/contracts/helpers/Context.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes calldata) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}

--- a/contracts/helpers/SafeERC20.sol
+++ b/contracts/helpers/SafeERC20.sol
@@ -87,15 +87,22 @@ library SafeERC20 {
         address spender,
         uint256 value
     ) internal {
-        uint256 newAllowance = token.allowance(address(this), spender) - value;
-        _callOptionalReturn(
-            token,
-            abi.encodeWithSelector(
-                token.approve.selector,
-                spender,
-                newAllowance
-            )
-        );
+        unchecked {
+            uint256 oldAllowance = token.allowance(address(this), spender);
+            require(
+                oldAllowance >= value,
+                "SafeERC20: decreased allowance below zero"
+            );
+            uint256 newAllowance = oldAllowance - value;
+            _callOptionalReturn(
+                token,
+                abi.encodeWithSelector(
+                    token.approve.selector,
+                    spender,
+                    newAllowance
+                )
+            );
+        }
     }
 
     /**

--- a/contracts/test/TestToken1.sol
+++ b/contracts/test/TestToken1.sol
@@ -27,8 +27,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
-contract OLToken is ERC20 {
-    constructor(uint256 _totalSupply) ERC20("OpenLawToken", "OLT") {
+contract TestToken1 is ERC20 {
+    constructor(uint256 _totalSupply) ERC20("TestToken1", "TT1") {
         _mint(msg.sender, _totalSupply * (10**uint256(decimals())));
     }
 }

--- a/contracts/test/TestToken2.sol
+++ b/contracts/test/TestToken2.sol
@@ -27,8 +27,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
-contract OLToken is ERC20 {
-    constructor(uint256 _totalSupply) ERC20("OpenLawToken", "OLT") {
+contract TestToken2 is ERC20 {
+    constructor(uint256 _totalSupply) ERC20("TestToken2", "TT2") {
         _mint(msg.sender, _totalSupply * (10**uint256(decimals())));
     }
 }

--- a/contracts/utils/ERC20.sol
+++ b/contracts/utils/ERC20.sol
@@ -1,21 +1,35 @@
-pragma solidity ^0.8.0;
 // SPDX-License-Identifier: MIT
 
+pragma solidity ^0.8.0;
+
+import "../helpers/Context.sol";
 import "./IERC20.sol";
 
 /**
- * @title Standard ERC20 token
+ * @dev Implementation of the {IERC20} interface.
  *
- * @dev Implementation of the basic standard token.
- * https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md
- * Originally based on code by FirstBlood:
- * https://github.com/Firstbloodio/token/blob/master/smart_contract/FirstBloodToken.sol
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
  *
- * This implementation emits additional Approval events, allowing applications to reconstruct the allowance status for
- * all accounts just by listening to said events. Note that this isn't required by the specification, and other
- * compliant implementations may not do it.
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
  */
-contract ERC20 is IERC20 {
+contract ERC20 is Context, IERC20 {
     mapping(address => uint256) private _balances;
 
     mapping(address => mapping(address => uint256)) private _allowances;
@@ -24,32 +38,25 @@ contract ERC20 is IERC20 {
 
     string private _name;
     string private _symbol;
-    uint8 private _decimals;
 
     /**
-     * @dev Sets the values for {name} and {symbol}, initializes {decimals} with
-     * a default value of 18.
+     * @dev Sets the values for {name} and {symbol}.
      *
-     * To select a different value for {decimals}, use {_setupDecimals}.
+     * The defaut value of {decimals} is 18. To select a different value for
+     * {decimals} you should overload it.
      *
      * All three of these values are immutable: they can only be set once during
      * construction.
      */
-    constructor(
-        string memory nameParam,
-        string memory symbolParam,
-        uint256 totalSupplyParam
-    ) {
-        _name = nameParam;
-        _symbol = symbolParam;
-        _decimals = 18;
-        _totalSupply = totalSupplyParam;
+    constructor(string memory name_, string memory symbol_) {
+        _name = name_;
+        _symbol = symbol_;
     }
 
     /**
      * @dev Returns the name of the token.
      */
-    function name() public view returns (string memory) {
+    function name() public view virtual returns (string memory) {
         return _name;
     }
 
@@ -57,7 +64,7 @@ contract ERC20 is IERC20 {
      * @dev Returns the symbol of the token, usually a shorter version of the
      * name.
      */
-    function symbol() public view returns (string memory) {
+    function symbol() public view virtual returns (string memory) {
         return _symbol;
     }
 
@@ -67,42 +74,62 @@ contract ERC20 is IERC20 {
      * be displayed to a user as `5,05` (`505 / 10 ** 2`).
      *
      * Tokens usually opt for a value of 18, imitating the relationship between
-     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
-     * called.
+     * Ether and Wei. This is the value {ERC20} uses, unless this function is
+     * overloaded;
      *
      * NOTE: This information is only used for _display_ purposes: it in
      * no way affects any of the arithmetic of the contract, including
      * {IERC20-balanceOf} and {IERC20-transfer}.
      */
-    function decimals() public view returns (uint8) {
-        return _decimals;
+    function decimals() public view virtual returns (uint8) {
+        return 18;
     }
 
     /**
-     * @dev Total number of tokens in existence
+     * @dev See {IERC20-totalSupply}.
      */
-    function totalSupply() public view override returns (uint256) {
+    function totalSupply() public view virtual override returns (uint256) {
         return _totalSupply;
     }
 
     /**
-     * @dev Gets the balance of the specified address.
-     * @param owner The address to query the balance of.
-     * @return An uint256 representing the amount owned by the passed address.
+     * @dev See {IERC20-balanceOf}.
      */
-    function balanceOf(address owner) public view override returns (uint256) {
-        return _balances[owner];
+    function balanceOf(address account)
+        public
+        view
+        virtual
+        override
+        returns (uint256)
+    {
+        return _balances[account];
     }
 
     /**
-     * @dev Function to check the amount of tokens that an owner allowed to a spender.
-     * @param owner address The address which owns the funds.
-     * @param spender address The address which will spend the funds.
-     * @return A uint256 specifying the amount of tokens still available for the spender.
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount)
+        public
+        virtual
+        override
+        returns (bool)
+    {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
      */
     function allowance(address owner, address spender)
         public
         view
+        virtual
         override
         returns (uint256)
     {
@@ -110,174 +137,226 @@ contract ERC20 is IERC20 {
     }
 
     /**
-     * @dev Transfer token for a specified address
-     * @param to The address to transfer to.
-     * @param value The amount to be transferred.
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
      */
-    function transfer(address to, uint256 value)
+    function approve(address spender, uint256 amount)
         public
+        virtual
         override
         returns (bool)
     {
-        _transfer(msg.sender, to, value);
+        _approve(_msgSender(), spender, amount);
         return true;
     }
 
     /**
-     * @dev Approve the passed address to spend the specified amount of tokens on behalf of msg.sender.
-     * Beware that changing an allowance with this method brings the risk that someone may use both the old
-     * and the new allowance by unfortunate transaction ordering. One possible solution to mitigate this
-     * race condition is to first reduce the spender's allowance to 0 and set the desired value afterwards:
-     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
-     * @param spender The address which will spend the funds.
-     * @param value The amount of tokens to be spent.
-     */
-    function approve(address spender, uint256 value)
-        public
-        override
-        returns (bool)
-    {
-        _approve(msg.sender, spender, value);
-        return true;
-    }
-
-    /**
-     * @dev Transfer tokens from one address to another.
-     * Note that while this function emits an Approval event, this is not required as per the specification,
-     * and other compliant implementations may not emit the event.
-     * @param from address The address which you want to send tokens from
-     * @param to address The address which you want to transfer to
-     * @param value uint256 the amount of tokens to be transferred
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20}.
+     *
+     * Requirements:
+     *
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
      */
     function transferFrom(
-        address from,
-        address to,
-        uint256 value
-    ) public override returns (bool) {
-        _transfer(from, to, value);
-        _approve(from, msg.sender, _allowances[from][msg.sender] - value);
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+
+        uint256 currentAllowance = _allowances[sender][_msgSender()];
+        require(
+            currentAllowance >= amount,
+            "ERC20: transfer amount exceeds allowance"
+        );
+        _approve(sender, _msgSender(), currentAllowance - amount);
+
         return true;
     }
 
     /**
-     * @dev Increase the amount of tokens that an owner allowed to a spender.
-     * approve should be called when allowed_[_spender] == 0. To increment
-     * allowed value is better to use this function to avoid 2 calls (and wait until
-     * the first transaction is mined)
-     * From MonolithDAO Token.sol
-     * Emits an Approval event.
-     * @param spender The address which will spend the funds.
-     * @param addedValue The amount of tokens to increase the allowance by.
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
      */
     function increaseAllowance(address spender, uint256 addedValue)
         public
+        virtual
         returns (bool)
     {
         _approve(
-            msg.sender,
+            _msgSender(),
             spender,
-            _allowances[msg.sender][spender] + addedValue
+            _allowances[_msgSender()][spender] + addedValue
         );
         return true;
     }
 
     /**
-     * @dev Decrease the amount of tokens that an owner allowed to a spender.
-     * approve should be called when allowed_[_spender] == 0. To decrement
-     * allowed value is better to use this function to avoid 2 calls (and wait until
-     * the first transaction is mined)
-     * From MonolithDAO Token.sol
-     * Emits an Approval event.
-     * @param spender The address which will spend the funds.
-     * @param subtractedValue The amount of tokens to decrease the allowance by.
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
      */
     function decreaseAllowance(address spender, uint256 subtractedValue)
         public
+        virtual
         returns (bool)
     {
-        _approve(
-            msg.sender,
-            spender,
-            _allowances[msg.sender][spender] - subtractedValue
+        uint256 currentAllowance = _allowances[_msgSender()][spender];
+        require(
+            currentAllowance >= subtractedValue,
+            "ERC20: decreased allowance below zero"
         );
+        _approve(_msgSender(), spender, currentAllowance - subtractedValue);
+
         return true;
     }
 
     /**
-     * @dev Transfer token for a specified addresses
-     * @param from The address to transfer from.
-     * @param to The address to transfer to.
-     * @param value The amount to be transferred.
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
      */
     function _transfer(
-        address from,
-        address to,
-        uint256 value
-    ) internal {
-        require(to != address(0), "to address should not be zero");
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
 
-        _balances[from] = _balances[from] - value;
-        _balances[to] = _balances[to] + value;
-        emit Transfer(from, to, value);
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        uint256 senderBalance = _balances[sender];
+        require(
+            senderBalance >= amount,
+            "ERC20: transfer amount exceeds balance"
+        );
+        _balances[sender] = senderBalance - amount;
+        _balances[recipient] += amount;
+
+        emit Transfer(sender, recipient, amount);
     }
 
-    /**
-     * @dev Internal function that mints an amount of the token and assigns it to
-     * an account. This encapsulates the modification of balances such that the
-     * proper events are emitted.
-     * @param account The account that will receive the created tokens.
-     * @param value The amount that will be created.
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements:
+     *
+     * - `to` cannot be the zero address.
      */
-    function _mint(address account, uint256 value) internal {
-        require(account != address(0), "to address should not be zero");
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
 
-        _totalSupply = _totalSupply + value;
-        _balances[account] = _balances[account] + value;
-        emit Transfer(address(0), account, value);
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply += amount;
+        _balances[account] += amount;
+        emit Transfer(address(0), account, amount);
     }
 
     /**
-     * @dev Internal function that burns an amount of the token of a given
-     * account.
-     * @param account The account whose tokens will be burnt.
-     * @param value The amount that will be burnt.
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements:
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
      */
-    function _burn(address account, uint256 value) internal {
-        require(account != address(0), "account address should not be zero");
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
 
-        _totalSupply = _totalSupply - value;
-        _balances[account] = _balances[account] - value;
-        emit Transfer(account, address(0), value);
+        _beforeTokenTransfer(account, address(0), amount);
+
+        uint256 accountBalance = _balances[account];
+        require(accountBalance >= amount, "ERC20: burn amount exceeds balance");
+        _balances[account] = accountBalance - amount;
+        _totalSupply -= amount;
+
+        emit Transfer(account, address(0), amount);
     }
 
     /**
-     * @dev Approve an address to spend another addresses' tokens.
-     * @param owner The address that owns the tokens.
-     * @param spender The address that will spend the tokens.
-     * @param value The number of tokens that can be spent.
+     * @dev Sets `amount` as the allowance of `spender` over the `owner` s tokens.
+     *
+     * This internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
      */
     function _approve(
         address owner,
         address spender,
-        uint256 value
-    ) internal {
-        require(spender != address(0), "sender address should not be zero");
-        require(owner != address(0), "owner address should not be zero");
+        uint256 amount
+    ) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
 
-        _allowances[owner][spender] = value;
-        emit Approval(owner, spender, value);
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
     }
 
     /**
-     * @dev Internal function that burns an amount of the token of a given
-     * account, deducting from the sender's allowance for said account. Uses the
-     * internal burn function.
-     * Emits an Approval event (reflecting the reduced allowance).
-     * @param account The account whose tokens will be burnt.
-     * @param value The amount that will be burnt.
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
      */
-    function _burnFrom(address account, uint256 value) internal {
-        _burn(account, value);
-        _approve(account, msg.sender, _allowances[account][msg.sender] - value);
-    }
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 amount
+    ) internal virtual {}
 }

--- a/contracts/utils/IERC20.sol
+++ b/contracts/utils/IERC20.sol
@@ -1,29 +1,87 @@
-pragma solidity ^0.8.0;
-
 // SPDX-License-Identifier: MIT
 
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
 interface IERC20 {
-    function transfer(address to, uint256 value) external returns (bool);
-
-    function approve(address spender, uint256 value) external returns (bool);
-
-    function transferFrom(
-        address from,
-        address to,
-        uint256 value
-    ) external returns (bool);
-
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
     function totalSupply() external view returns (uint256);
 
-    function balanceOf(address who) external view returns (uint256);
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
 
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount)
+        external
+        returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
     function allowance(address owner, address spender)
         external
         view
         returns (uint256);
 
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
     event Transfer(address indexed from, address indexed to, uint256 value);
 
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
     event Approval(
         address indexed owner,
         address indexed spender,

--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -44,7 +44,8 @@ module.exports = async function(deployer, network) {
       votingPeriod: 60, //in seconds
       gracePeriod: 60, // in seconds
       offchainVoting: true,
-      chainId: getNetworkDetails(network).chainId
+      chainId: getNetworkDetails(network).chainId,
+      deployTestTokens: true
     });
   } else if (network === 'test' || network === 'coverage') {
     dao = await deployDao(deployer, {
@@ -55,7 +56,8 @@ module.exports = async function(deployer, network) {
       votingPeriod: 10,
       gracePeriod: 1,
       offchainVoting: true,
-      chainId: getNetworkDetails(network).chainId
+      chainId: getNetworkDetails(network).chainId,
+      deployTestTokens: false
     });
   }
   if(dao) {

--- a/test/adapters/non-voting.membership.test.js
+++ b/test/adapters/non-voting.membership.test.js
@@ -33,7 +33,7 @@ const {
   LOOT,
   sharePrice,
   remaining,
-  OLTokenContract,
+  OLToken,
   OnboardingContract,
   VotingContract,
   BankExtension,
@@ -100,7 +100,7 @@ contract("LAOLAND - Non Voting Onboarding Adapter", async (accounts) => {
 
     // Issue OpenLaw ERC20 Basic Token for tests
     let tokenSupply = 1000000;
-    let oltContract = await OLTokenContract.new(tokenSupply);
+    let oltContract = await OLToken.new(tokenSupply);
 
     let lootSharePrice = 10;
     let nbOfLootShares = 100000000;

--- a/test/adapters/onboarding.test.js
+++ b/test/adapters/onboarding.test.js
@@ -33,7 +33,7 @@ const {
   SHARES,
   sharePrice,
   remaining,
-  OLTokenContract,
+  OLToken,
   numberOfShares,
   OnboardingContract,
   VotingContract,
@@ -130,7 +130,7 @@ contract("LAOLAND - Onboarding Adapter", async (accounts) => {
 
     // Issue OpenLaw ERC20 Basic Token for tests
     const tokenSupply = 1000000;
-    let oltContract = await OLTokenContract.new(tokenSupply);
+    let oltContract = await OLToken.new(tokenSupply);
 
     const nbOfERC20Shares = 100000000;
     const erc20SharePrice = toBN("10");
@@ -350,7 +350,7 @@ contract("LAOLAND - Onboarding Adapter", async (accounts) => {
 
     // Issue OpenLaw ERC20 Basic Token for tests
     const tokenSupply = 1000000;
-    let oltContract = await OLTokenContract.new(tokenSupply);
+    let oltContract = await OLToken.new(tokenSupply);
 
     const nbOfERC20Shares = 100000000;
     const erc20SharePrice = toBN("10");

--- a/test/adapters/ragequit.test.js
+++ b/test/adapters/ragequit.test.js
@@ -36,7 +36,7 @@ const {
   ETH_TOKEN,
   SHARES,
   LOOT,
-  OLTokenContract,
+  OLToken,
   OnboardingContract,
   VotingContract,
   RagequitContract,
@@ -398,7 +398,7 @@ contract("LAOLAND - Ragequit Adapter", async (accounts) => {
 
     // Issue OpenLaw ERC20 Basic Token for tests
     let tokenSupply = 1000000;
-    let oltContract = await OLTokenContract.new(tokenSupply);
+    let oltContract = await OLToken.new(tokenSupply);
 
     let dao = await createDao(
       myAccount,

--- a/test/adapters/tribute.test.js
+++ b/test/adapters/tribute.test.js
@@ -31,7 +31,7 @@ const {
   getContract,
   GUILD,
   SHARES,
-  OLTokenContract,
+  OLToken,
   TributeContract,
   VotingContract,
   BankExtension,
@@ -54,7 +54,7 @@ contract("LAOLAND - Tribute Adapter", async (accounts) => {
 
     // Issue OpenLaw ERC20 Basic Token for tests
     const tokenSupply = 1000000;
-    let oltContract = await OLTokenContract.new(tokenSupply);
+    let oltContract = await OLToken.new(tokenSupply);
 
     // Transfer OLTs to myAccount
     const initialTokenBalance = toBN("100");
@@ -170,7 +170,7 @@ contract("LAOLAND - Tribute Adapter", async (accounts) => {
 
     // Issue OpenLaw ERC20 Basic Token for tests
     const tokenSupply = 1000000;
-    let oltContract = await OLTokenContract.new(tokenSupply);
+    let oltContract = await OLToken.new(tokenSupply);
 
     // Transfer OLTs to myAccount
     const initialTokenBalance = toBN("100");
@@ -271,7 +271,7 @@ contract("LAOLAND - Tribute Adapter", async (accounts) => {
 
     // Issue OpenLaw ERC20 Basic Token for tests
     const tokenSupply = 1000000;
-    let oltContract = await OLTokenContract.new(tokenSupply);
+    let oltContract = await OLToken.new(tokenSupply);
 
     // Transfer OLTs to myAccount
     const initialTokenBalance = toBN("100");

--- a/utils/DaoFactory.js
+++ b/utils/DaoFactory.js
@@ -316,6 +316,7 @@ async function deployDao(deployer, options) {
   const maxChunks = options.maximumChunks || maximumChunks;
   const isOffchainVoting = !!options.offchainVoting;
   const chainId = options.chainId || 1;
+  const deployTestTokens = !!options.deployTestTokens;
 
   await deployer.deploy(DaoRegistry);
 
@@ -379,10 +380,12 @@ async function deployDao(deployer, options) {
   }
 
   // deploy test token contracts (for testing convenience)
-  const tokenSupply = 1000000;
-  await deployer.deploy(OLToken, tokenSupply);
-  await deployer.deploy(TestToken1, tokenSupply);
-  await deployer.deploy(TestToken2, tokenSupply);
+  if (deployTestTokens) {
+    const tokenSupply = 1000000;
+    await deployer.deploy(OLToken, tokenSupply);
+    await deployer.deploy(TestToken1, tokenSupply);
+    await deployer.deploy(TestToken2, tokenSupply);
+  }
 
   return dao;
 }

--- a/utils/DaoFactory.js
+++ b/utils/DaoFactory.js
@@ -44,7 +44,9 @@ const sharePrice = toBN(toWei("120", "finney"));
 const remaining = sharePrice.sub(toBN("50000000000000"));
 const maximumChunks = toBN("11");
 
-const OLTokenContract = artifacts.require("./test/OLT");
+const OLToken = artifacts.require("./test/OLToken");
+const TestToken1 = artifacts.require("./test/TestToken1");
+const TestToken2 = artifacts.require("./test/TestToken2");
 
 const DaoFactory = artifacts.require("./core/DaoFactory");
 const DaoRegistry = artifacts.require("./core/DaoRegistry");
@@ -376,6 +378,12 @@ async function deployDao(deployer, options) {
     );
   }
 
+  // deploy test token contracts (for testing convenience)
+  const tokenSupply = 1000000;
+  await deployer.deploy(OLToken, tokenSupply);
+  await deployer.deploy(TestToken1, tokenSupply);
+  await deployer.deploy(TestToken2, tokenSupply);
+
   return dao;
 }
 
@@ -624,7 +632,9 @@ module.exports = {
   sharePrice,
   remaining,
   ETH_TOKEN,
-  OLTokenContract,
+  OLToken,
+  TestToken1,
+  TestToken2,
   DaoFactory,
   DaoRegistry,
   VotingContract,

--- a/utils/DaoFactory.js
+++ b/utils/DaoFactory.js
@@ -66,7 +66,7 @@ const OffchainVotingContract = artifacts.require(
 const TributeContract = artifacts.require("./adapters/TributeContract");
 const DistributeContract = artifacts.require("./adapters/DistributeContract");
 
-async function prepareAapters(deployer) {
+async function prepareAdapters(deployer) {
   let voting;
   let configuration;
   let ragequit;
@@ -149,8 +149,7 @@ async function addDefaultAdapters(
     withdraw,
     tribute,
     distribute,
-
-  } = await prepareAapters(deployer);
+  } = await prepareAdapters(deployer);
   await configureDao(
     daoFactory,
     dao,
@@ -602,7 +601,7 @@ async function getContract(dao, id, contractFactory) {
 }
 
 module.exports = {
-  prepareAapters,
+  prepareAdapters,
   advanceTime,
   createDao,
   deployDao,


### PR DESCRIPTION
- Updates ERC20 contracts to latest OpenZeppelin versions
- Adds new test token contracts
- Cleans up creation and naming of existing `OLToken` contract
- Adds option to deploy test token contracts with `deployDao`

Separately, we discovered that the use of the `SafeERC20` wrappers are failing with Ganache GUI for some reason (invalid opcode causing the transaction to exceed gas limits). They are working as expected with ganache-cli. To work with the current `ganache` network config in `truffle-config.js`, the ganache network should be launched with: `ganache-cli --port 7545 --networkId 1337`.