### PR TITLE
GH-171: Added function to read the voting adapter name

### DIFF
--- a/contracts/adapters/Managing.sol
+++ b/contracts/adapters/Managing.sol
@@ -53,7 +53,7 @@ contract ManagingContract is IManaging, DaoConstants, MemberGuard {
     /**
      * @notice returns the voting adapter name that is configured in the DAO.
      */
-    function getVotingAdapterName() external returns (string) {
+    function getVotingAdapterName(DaoRegistry dao) external returns (string) {
         IVoting votingContract = IVoting(dao.getAdapterAddress(VOTING));
         return votingContract.getAdapterName();
     }

--- a/contracts/adapters/Managing.sol
+++ b/contracts/adapters/Managing.sol
@@ -50,6 +50,14 @@ contract ManagingContract is IManaging, DaoConstants, MemberGuard {
         revert("fallback revert");
     }
 
+    /**
+     * @notice returns the voting adapter name that is configured in the DAO.
+     */
+    function getVotingAdapterName() external returns (string) {
+        IVoting votingContract = IVoting(dao.getAdapterAddress(VOTING));
+        return votingContract.getAdapterName();
+    }
+
     function createAdapterChangeRequest(
         DaoRegistry dao,
         bytes32 proposalId,

--- a/contracts/adapters/Managing.sol
+++ b/contracts/adapters/Managing.sol
@@ -53,7 +53,12 @@ contract ManagingContract is IManaging, DaoConstants, MemberGuard {
     /**
      * @notice returns the voting adapter name that is configured in the DAO.
      */
-    function getVotingAdapterName(DaoRegistry dao) external returns (string) {
+    function getVotingAdapterName(DaoRegistry dao)
+        external
+        view
+        override
+        returns (string memory)
+    {
         IVoting votingContract = IVoting(dao.getAdapterAddress(VOTING));
         return votingContract.getAdapterName();
     }

--- a/contracts/adapters/interfaces/IManaging.sol
+++ b/contracts/adapters/interfaces/IManaging.sol
@@ -29,7 +29,9 @@ SOFTWARE.
  */
 
 interface IManaging {
-    function getVotingAdapterName(DaoRegistry dao) external returns (string memory);
+    function getVotingAdapterName(DaoRegistry dao)
+        external
+        returns (string memory);
 
     function createAdapterChangeRequest(
         DaoRegistry dao,

--- a/contracts/adapters/interfaces/IManaging.sol
+++ b/contracts/adapters/interfaces/IManaging.sol
@@ -29,7 +29,7 @@ SOFTWARE.
  */
 
 interface IManaging {
-    function getVotingAdapterName(DaoRegistry dao) external returns (string);
+    function getVotingAdapterName(DaoRegistry dao) external returns (string memory);
 
     function createAdapterChangeRequest(
         DaoRegistry dao,

--- a/contracts/adapters/interfaces/IManaging.sol
+++ b/contracts/adapters/interfaces/IManaging.sol
@@ -29,7 +29,6 @@ SOFTWARE.
  */
 
 interface IManaging {
-
     function getVotingAdapterName() external returns (string);
 
     function createAdapterChangeRequest(

--- a/contracts/adapters/interfaces/IManaging.sol
+++ b/contracts/adapters/interfaces/IManaging.sol
@@ -29,7 +29,7 @@ SOFTWARE.
  */
 
 interface IManaging {
-    function getVotingAdapterName() external returns (string);
+    function getVotingAdapterName(DaoRegistry dao) external returns (string);
 
     function createAdapterChangeRequest(
         DaoRegistry dao,

--- a/contracts/adapters/interfaces/IManaging.sol
+++ b/contracts/adapters/interfaces/IManaging.sol
@@ -29,6 +29,9 @@ SOFTWARE.
  */
 
 interface IManaging {
+
+    function getVotingAdapterName() external returns (string);
+
     function createAdapterChangeRequest(
         DaoRegistry dao,
         bytes32 proposalId,

--- a/contracts/adapters/interfaces/IVoting.sol
+++ b/contracts/adapters/interfaces/IVoting.sol
@@ -38,7 +38,7 @@ interface IVoting {
         GRACE_PERIOD
     }
 
-    function getAdapterName() public pure returns (string memory);
+    function getAdapterName() external pure returns (string memory);
 
     function startNewVotingForProposal(
         DaoRegistry dao,

--- a/contracts/adapters/interfaces/IVoting.sol
+++ b/contracts/adapters/interfaces/IVoting.sol
@@ -38,6 +38,8 @@ interface IVoting {
         GRACE_PERIOD
     }
 
+    function getAdapterName() external returns (string);
+
     function startNewVotingForProposal(
         DaoRegistry dao,
         bytes32 proposalId,

--- a/contracts/adapters/interfaces/IVoting.sol
+++ b/contracts/adapters/interfaces/IVoting.sol
@@ -38,7 +38,7 @@ interface IVoting {
         GRACE_PERIOD
     }
 
-    function getAdapterName() external returns (string);
+    function getAdapterName() public pure returns (string memory);
 
     function startNewVotingForProposal(
         DaoRegistry dao,

--- a/contracts/adapters/voting/OffchainVoting.sol
+++ b/contracts/adapters/voting/OffchainVoting.sol
@@ -75,7 +75,7 @@ contract OffchainVotingContract is
 
     string public constant ADAPTER_NAME = "OffchainVotingContract";
 
-    function getAdapterName() external override returns (string) {
+    function getAdapterName() override public pure returns (string memory) {
         return ADAPTER_NAME;
     }
 

--- a/contracts/adapters/voting/OffchainVoting.sol
+++ b/contracts/adapters/voting/OffchainVoting.sol
@@ -73,6 +73,12 @@ contract OffchainVotingContract is
 
     uint256 public chainId;
 
+    string public constant ADAPTER_NAME = "OffchainVotingContract";
+
+    function getAdapterName() override external returns (string) {
+        return ADAPTER_NAME;
+    }
+
     function DOMAIN_SEPARATOR(DaoRegistry dao, address actionId)
         public
         view

--- a/contracts/adapters/voting/OffchainVoting.sol
+++ b/contracts/adapters/voting/OffchainVoting.sol
@@ -75,7 +75,7 @@ contract OffchainVotingContract is
 
     string public constant ADAPTER_NAME = "OffchainVotingContract";
 
-    function getAdapterName() override public pure returns (string memory) {
+    function getAdapterName() public pure override returns (string memory) {
         return ADAPTER_NAME;
     }
 

--- a/contracts/adapters/voting/OffchainVoting.sol
+++ b/contracts/adapters/voting/OffchainVoting.sol
@@ -75,7 +75,7 @@ contract OffchainVotingContract is
 
     string public constant ADAPTER_NAME = "OffchainVotingContract";
 
-    function getAdapterName() public pure override returns (string memory) {
+    function getAdapterName() external pure override returns (string memory) {
         return ADAPTER_NAME;
     }
 

--- a/contracts/adapters/voting/OffchainVoting.sol
+++ b/contracts/adapters/voting/OffchainVoting.sol
@@ -75,7 +75,7 @@ contract OffchainVotingContract is
 
     string public constant ADAPTER_NAME = "OffchainVotingContract";
 
-    function getAdapterName() override external returns (string) {
+    function getAdapterName() external override returns (string) {
         return ADAPTER_NAME;
     }
 

--- a/contracts/adapters/voting/Voting.sol
+++ b/contracts/adapters/voting/Voting.sol
@@ -49,7 +49,7 @@ contract VotingContract is IVoting, DaoConstants, MemberGuard, AdapterGuard {
 
     string public constant ADAPTER_NAME = "VotingContract";
 
-    function getAdapterName() override public pure returns (string memory) {
+    function getAdapterName() public pure override returns (string memory) {
         return ADAPTER_NAME;
     }
 

--- a/contracts/adapters/voting/Voting.sol
+++ b/contracts/adapters/voting/Voting.sol
@@ -47,6 +47,12 @@ contract VotingContract is IVoting, DaoConstants, MemberGuard, AdapterGuard {
 
     mapping(address => mapping(bytes32 => Voting)) public votes;
 
+    string constant public ADAPTER_NAME = "VotingContract";
+
+    function getAdapterName() override external returns (string) {
+        return ADAPTER_NAME;
+    }
+
     function configureDao(
         DaoRegistry dao,
         uint256 votingPeriod,

--- a/contracts/adapters/voting/Voting.sol
+++ b/contracts/adapters/voting/Voting.sol
@@ -49,7 +49,7 @@ contract VotingContract is IVoting, DaoConstants, MemberGuard, AdapterGuard {
 
     string public constant ADAPTER_NAME = "VotingContract";
 
-    function getAdapterName() public pure override returns (string memory) {
+    function getAdapterName() external pure override returns (string memory) {
         return ADAPTER_NAME;
     }
 

--- a/contracts/adapters/voting/Voting.sol
+++ b/contracts/adapters/voting/Voting.sol
@@ -49,7 +49,7 @@ contract VotingContract is IVoting, DaoConstants, MemberGuard, AdapterGuard {
 
     string public constant ADAPTER_NAME = "VotingContract";
 
-    function getAdapterName() external override returns (string) {
+    function getAdapterName() override public pure returns (string memory) {
         return ADAPTER_NAME;
     }
 

--- a/contracts/adapters/voting/Voting.sol
+++ b/contracts/adapters/voting/Voting.sol
@@ -47,9 +47,9 @@ contract VotingContract is IVoting, DaoConstants, MemberGuard, AdapterGuard {
 
     mapping(address => mapping(bytes32 => Voting)) public votes;
 
-    string constant public ADAPTER_NAME = "VotingContract";
+    string public constant ADAPTER_NAME = "VotingContract";
 
-    function getAdapterName() override external returns (string) {
+    function getAdapterName() external override returns (string) {
         return ADAPTER_NAME;
     }
 

--- a/test/adapters/managing.test.js
+++ b/test/adapters/managing.test.js
@@ -305,4 +305,19 @@ contract("LAOLAND - Managing Adapter", async (accounts) => {
     let newOnboardingAddress = await dao.getAdapterAddress(sha3("onboarding"));
     assert.equal(newOnboardingAddress.toString(), newAdapterAddress.toString());
   });
+
+  it("should be possible to get the voting contract name", async () => {
+    const daoOwner = accounts[1];
+
+    // Create the new DAO
+    let dao = await createDao(daoOwner);
+    let managingContract = await dao.getAdapterAddress(sha3("managing"));
+    let managing = await ManagingContract.at(managingContract);
+
+    // Check if the voting adapter (VotingContract) was added to the Registry
+    let votingAdapterName = await managing.getVotingAdapterName(dao.address, {
+      from: daoOwner,
+    });
+    assert.equal(votingAdapterName, "VotingContract");
+  });
 });


### PR DESCRIPTION
This PR allows the external world to retrieve which voting adapter is configured in the DAO. In order to read that, a tx must be sent to Managing.sol contract, to call the function`getVotingAdapterName(dao)` - which will load the current voting mechanism and get its contract name using `votingContract.getAdapterName()`.


Closes #171 