### PR TITLE
Fix Rinkeby deploy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@graphprotocol/graph-cli": "^0.18.0",
         "@graphprotocol/graph-ts": "^0.18.1",
         "@smartdec/smartcheck": "^2.0.1",
+        "dotenv": "^8.2.0",
         "eth-gas-reporter": "^0.2.20",
         "prettier": "^2.1.2",
         "prettier-plugin-solidity": "^1.0.0-beta.3",
@@ -2393,6 +2394,15 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
+    "node_modules/dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/drbg.js": {
       "version": "1.0.1",
@@ -15523,6 +15533,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true
     },
     "drbg.js": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@graphprotocol/graph-cli": "^0.18.0",
     "@graphprotocol/graph-ts": "^0.18.1",
     "@smartdec/smartcheck": "^2.0.1",
+    "dotenv": "^8.2.0",
     "eth-gas-reporter": "^0.2.20",
     "prettier": "^2.1.2",
     "prettier-plugin-solidity": "^1.0.0-beta.3",

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -24,6 +24,8 @@
 // const fs = require('fs');
 // const mnemonic = fs.readFileSync(".secret").toString().trim();
 
+require("dotenv").config();
+
 module.exports = {
   /**
    * Networks define how you connect to your ethereum client and let you set the


### PR DESCRIPTION
Adds `dotenv` to be able to use `.env` file for configured Rinkeby deployment.