### PR TITLE
Fixes block number check to include "or equal to"

### DIFF
--- a/contracts/adapters/voting/OffchainVoting.sol
+++ b/contracts/adapters/voting/OffchainVoting.sol
@@ -508,7 +508,7 @@ contract OffchainVotingContract is
         address addr = recover(proposalHash, proposal.sig);
         require(dao.isActiveMember(addr), "noActiveMember");
         require(
-            blockNumber < block.number,
+            blockNumber <= block.number,
             "snapshot block number should not be in the future"
         );
         require(blockNumber > 0, "block number cannot be 0");


### PR DESCRIPTION
`OffchainVoting`: when the `estimateGas` function runs in the FE on `sponsorProposal` the logic `require( blockNumber < block.number, "snapshot block number should not be in the future" )` (which is technically correct) will fail. To fix it, @adridadou recommended using `<=` for the operator.